### PR TITLE
모임 생성 - 제목 & 장소

### DIFF
--- a/Baggle/Baggle/DesignSystem/View/TextField/BaggleTextField.swift
+++ b/Baggle/Baggle/DesignSystem/View/TextField/BaggleTextField.swift
@@ -133,6 +133,9 @@ struct BaggleTextField: View {
             .onChange(of: self.isFocused) { newValue in
                 viewStore.send(.isFocused(newValue))
             }
+            .onAppear {
+                isFocused = viewStore.state.isFocused
+            }
         }
     }
 }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Place/CreatePlaceFeature.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Place/CreatePlaceFeature.swift
@@ -10,16 +10,27 @@ import ComposableArchitecture
 struct CreatePlaceFeature: ReducerProtocol {
 
     struct State: Equatable {
-        // MARK: - Scope State
+
+        // Button
+        var nextButtonDisabled: Bool = true
+
+        // Child State
+        var textFieldState = BaggleTextFieldFeature.State(maxCount: 20, textFieldState: .inactive)
     }
 
     enum Action: Equatable {
 
-        // MARK: - Tap
-
+        // Tap
         case nextButtonTapped
+        case submitButtonTapped
 
-        // MARK: - Scope Action
+        // Move Screen
+        case moveToNextScreen
+
+        // Child Action
+        case textFieldAction(BaggleTextFieldFeature.Action)
+
+        // Delegate
         case delegate(Delegate)
 
         enum Delegate {
@@ -31,14 +42,42 @@ struct CreatePlaceFeature: ReducerProtocol {
 
         // MARK: - Scope
 
+        Scope(state: \.textFieldState, action: /Action.textFieldAction) {
+            BaggleTextFieldFeature()
+        }
+
         // MARK: - Reduce
 
-        Reduce { _, action in
+        Reduce { state, action in
 
             switch action {
-
+                // Tap
             case .nextButtonTapped:
+                return .run { send in await send(.moveToNextScreen)}
+
+            case .submitButtonTapped:
+                if state.textFieldState.text.isEmpty {
+                    return .run { send in
+                        await send(.textFieldAction(.changeState(.invalid("장소를 입력해주세요."))))
+                    }
+                } else {
+                    return .run { send in await send(.moveToNextScreen)}
+                }
+
+            case .moveToNextScreen:
                 return .run { send in await send(.delegate(.moveToNext)) }
+
+                // TextField
+            case let .textFieldAction(.textChanged(text)):
+                if text.isEmpty {
+                    state.nextButtonDisabled = true
+                } else {
+                    state.nextButtonDisabled = false
+                }
+                return .none
+
+            case .textFieldAction:
+                return .none
 
             case .delegate(.moveToNext):
                 return .none

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Place/CreatePlaceFeature.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Place/CreatePlaceFeature.swift
@@ -15,7 +15,11 @@ struct CreatePlaceFeature: ReducerProtocol {
         var nextButtonDisabled: Bool = true
 
         // Child State
-        var textFieldState = BaggleTextFieldFeature.State(maxCount: 20, textFieldState: .inactive)
+        var textFieldState = BaggleTextFieldFeature.State(
+            maxCount: 20,
+            textFieldState: .inactive,
+            isFocused: true
+        )
     }
 
     enum Action: Equatable {

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Place/CreatePlaceView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Place/CreatePlaceView.swift
@@ -17,8 +17,24 @@ struct CreatePlaceView: View {
 
         WithViewStore(self.store, observe: { $0 }) { viewStore in
             VStack {
-                Text("장소를 정하세요")
-                    .font(.largeTitle)
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("약속 장소는 어디인가요?")
+                        .font(.title2)
+
+                    BaggleTextField(
+                        store: self.store.scope(
+                            state: \.textFieldState,
+                            action: CreatePlaceFeature.Action.textFieldAction
+                        ),
+                        placeholder: "ex. 성수역 2번 출구",
+                        title: .title("약속 장소를 입력하세요.")
+                    )
+                    .submitLabel(.done)
+                    .onSubmit {
+                        viewStore.send(.submitButtonTapped)
+                    }
+                }
+                .padding()
 
                 Spacer()
 
@@ -27,7 +43,9 @@ struct CreatePlaceView: View {
                 } label: {
                     Text("다음")
                 }
+                .padding(.bottom, 10)
                 .buttonStyle(BagglePrimaryStyle())
+                .disabled(viewStore.state.nextButtonDisabled)
             }
         }
     }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Place/CreatePlaceView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Place/CreatePlaceView.swift
@@ -47,6 +47,10 @@ struct CreatePlaceView: View {
                 .buttonStyle(BagglePrimaryStyle())
                 .disabled(viewStore.state.nextButtonDisabled)
             }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                hideKeyboard()
+            }
         }
     }
 }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleFeature.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleFeature.swift
@@ -89,7 +89,7 @@ struct CreateTitleFeature: ReducerProtocol {
 
                 // View
             case .onAppear:
-                return .none
+                return .run { send in await send(.textFieldAction(.isFocused(true)))}
 
                 // Tap
             case .cancelButtonTapped:

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleFeature.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleFeature.swift
@@ -17,7 +17,11 @@ struct CreateTitleFeature: ReducerProtocol {
         var nextButtonDisabled: Bool = true
 
         // Child State
-        var textFieldState = BaggleTextFieldFeature.State(maxCount: 20, textFieldState: .inactive)
+        var textFieldState = BaggleTextFieldFeature.State(
+            maxCount: 20,
+            textFieldState: .inactive,
+            isFocused: true
+        )
         var path = StackState<Child.State>()
     }
 

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleView.swift
@@ -21,8 +21,24 @@ struct CreateTitleView: View {
         ) {
             WithViewStore(self.store, observe: { $0 }) { viewStore in
                 VStack {
-                    Text("제목을 정하세요")
-                        .font(.largeTitle)
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text("친구들과 약속을 잡아보세요!")
+                            .font(.title2)
+
+                        BaggleTextField(
+                            store: self.store.scope(
+                                state: \.textFieldState,
+                                action: CreateTitleFeature.Action.textFieldAction
+                            ),
+                            placeholder: "ex. 바글이와 저녁 약속",
+                            title: .title("어떤 약속인가요?")
+                        )
+                        .submitLabel(.done)
+                        .onSubmit {
+                            viewStore.send(.submitButtonTapped)
+                        }
+                    }
+                    .padding()
 
                     Spacer()
 
@@ -31,7 +47,9 @@ struct CreateTitleView: View {
                     } label: {
                         Text("다음")
                     }
+                    .padding(.bottom, 10)
                     .buttonStyle(BagglePrimaryStyle())
+                    .disabled(viewStore.state.nextButtonDisabled)
                 }
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
@@ -39,6 +57,9 @@ struct CreateTitleView: View {
                             viewStore.send(.cancelButtonTapped)
                         }
                     }
+                }
+                .onAppear {
+                    viewStore.send(.onAppear)
                 }
             }
         } destination: { pathState in

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleView.swift
@@ -58,9 +58,6 @@ struct CreateTitleView: View {
                         }
                     }
                 }
-                .onAppear {
-//                    viewStore.send(.onAppear)
-                }
                 .contentShape(Rectangle())
                 .onTapGesture {
                     hideKeyboard()

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleView.swift
@@ -59,7 +59,11 @@ struct CreateTitleView: View {
                     }
                 }
                 .onAppear {
-                    viewStore.send(.onAppear)
+//                    viewStore.send(.onAppear)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    hideKeyboard()
                 }
             }
         } destination: { pathState in

--- a/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
@@ -21,8 +21,7 @@ struct HomeFeature: ReducerProtocol {
     struct State: Equatable {
         // MARK: - Scope State
 
-        var textFieldState = BaggleTextFieldFeature.State(maxCount: 10,
-                                                          textFieldState: .inactive)
+        var textFieldState = BaggleTextFieldFeature.State(maxCount: 10, textFieldState: .inactive)
         var showMeetingDetail: Bool = false
     }
 


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #43 

## 내용
<!--
로직 설명  
--> 
- 모임 생성 제목 & 장소에 TextField를 추가했습니다.
- 한 글자라도 입력시 다음 화면으로 넘어갑니다.
- 키보드 "완료" 버튼 클릭시에도 다음 화면으로 넘어갑니다.
  - 버튼 클릭시 빈 문자면 invalid 상태가 됩니다.
- 키보드 아닌 화면을 터치시 키보드를 숨깁니다. Spacer()에 백그라운드 컬러가 없으면 터치 인식이 안되서  `.contentShape(Rectangle()) `를 사용해줬습니다. 아래 링크 참고해주세요.

<br/>

**+추가** 
화면 진입시 키보드 올라오는 기능 추가헀습니다.   
1. TextField의 @FocusState를 true로 바꿔주면 올라옴
2. `BaggleTextFieldFeature`의 이니셜라이져에 초기 값을 넣어줌
3. `BaggleTextField` - `OnAppear` 메소드에서 값을 설정해줌   
(그 전에는 초기화할 때 @FocusState에 직접 할당을 해줘서 안 됐는데 OnAppear에서 사용하니 되네요. 아마 화면이 그려지기 전에 이벤트가 발생해서, focus 될 Textfield를 못 찾았나 봅니다.)


<br/>

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

화면 진입시 키보드 올라오는 기능 X
![Simulator Screen Recording - iPhone 13 mini - 2023-07-31 at 20 22 59](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/62b5ba06-807d-428d-9ad5-0d3cf5f2a539)

화면 진입시 키보드 올라오는 기능 O
![Simulator Screen Recording - iPhone 13 mini - 2023-07-31 at 22 11 12](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/f953b047-1ad0-46e0-91fa-947d51d4130d)


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- ~~화면에 진입하자마자 키보드가 올라오도록 onAppear에서 focued 상태를 바꿔줬는데 안 올라오네요....~~

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
-`.contentShape(Rectangle()) ` : https://stackoverflow.com/questions/57191013/swiftui-cant-tap-in-spacer-of-hstack
