### PR TITLE
모임 생성 View 완성 (이였던것)

### DIFF
--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1406858B2A7B676D00824A93 /* CreateDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1406858A2A7B676D00824A93 /* CreateDescription.swift */; };
 		140C54382A74F42900CF1CB4 /* NicknameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140C54372A74F42900CF1CB4 /* NicknameValidator.swift */; };
 		140C543E2A74F54B00CF1CB4 /* String+Regex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140C543D2A74F54B00CF1CB4 /* String+Regex.swift */; };
 		140E88112A64B626005119F8 /* BaggleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140E88102A64B626005119F8 /* BaggleApp.swift */; };
@@ -107,6 +108,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1406858A2A7B676D00824A93 /* CreateDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDescription.swift; sourceTree = "<group>"; };
 		140C54372A74F42900CF1CB4 /* NicknameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameValidator.swift; sourceTree = "<group>"; };
 		140C543D2A74F54B00CF1CB4 /* String+Regex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Regex.swift"; sourceTree = "<group>"; };
 		140E880D2A64B626005119F8 /* Baggle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Baggle.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -369,6 +371,7 @@
 				1413925D2A78E66600249C8A /* CircleNumberView.swift */,
 				141392612A78EBD300249C8A /* CreateStatus.swift */,
 				1413925F2A78E81D00249C8A /* PageIndicator.swift */,
+				1406858A2A7B676D00824A93 /* CreateDescription.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -938,6 +941,7 @@
 				14B7A0412A753D4800B8E202 /* SignUpService.swift in Sources */,
 				14E5064E2A6B88F7008D5778 /* SignUpView.swift in Sources */,
 				14EBE4BE2A68130F007537C8 /* LoginView.swift in Sources */,
+				1406858B2A7B676D00824A93 /* CreateDescription.swift in Sources */,
 				2B5BE6B22A77A40900F25474 /* MeetingDetailService.swift in Sources */,
 				2BABCB2C2A76D1AF00AFECA3 /* MeetingDetailFeature.swift in Sources */,
 				2B39F21C2A738BB100E034A3 /* SendInvitation.swift in Sources */,
@@ -964,7 +968,6 @@
 				146C51EB2A79406700FF3142 /* BaggleTimePickerView.swift in Sources */,
 				14F2D7AE2A7287AD000ED0EE /* ProfileImageModel.swift in Sources */,
 				2BABCB222A76CFDC00AFECA3 /* Notification+Name.swift in Sources */,
-				146C51E72A793D3600FF3142 /* BaggleDatePickerFeature.swift in Sources */,
 				2BF268202A77828100F32ADF /* Meeting.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		1406858B2A7B676D00824A93 /* CreateDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1406858A2A7B676D00824A93 /* CreateDescription.swift */; };
 		140C54382A74F42900CF1CB4 /* NicknameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140C54372A74F42900CF1CB4 /* NicknameValidator.swift */; };
-		140C543E2A74F54B00CF1CB4 /* String+Regex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140C543D2A74F54B00CF1CB4 /* String+Regex.swift */; };
+		140C543E2A74F54B00CF1CB4 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140C543D2A74F54B00CF1CB4 /* String+.swift */; };
 		140E88112A64B626005119F8 /* BaggleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140E88102A64B626005119F8 /* BaggleApp.swift */; };
 		140E88132A64B626005119F8 /* AppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140E88122A64B626005119F8 /* AppView.swift */; };
 		140E88152A64B627005119F8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 140E88142A64B627005119F8 /* Assets.xcassets */; };
@@ -110,7 +110,7 @@
 /* Begin PBXFileReference section */
 		1406858A2A7B676D00824A93 /* CreateDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDescription.swift; sourceTree = "<group>"; };
 		140C54372A74F42900CF1CB4 /* NicknameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameValidator.swift; sourceTree = "<group>"; };
-		140C543D2A74F54B00CF1CB4 /* String+Regex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Regex.swift"; sourceTree = "<group>"; };
+		140C543D2A74F54B00CF1CB4 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		140E880D2A64B626005119F8 /* Baggle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Baggle.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		140E88102A64B626005119F8 /* BaggleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggleApp.swift; sourceTree = "<group>"; };
 		140E88122A64B626005119F8 /* AppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
@@ -630,7 +630,7 @@
 				146C51DE2A79143400FF3142 /* Date */,
 				2BABCB272A76D08300AFECA3 /* PostObserverAction.swift */,
 				14F2D7B02A728A2B000ED0EE /* PhotosPickerItem+loadTransferable.swift */,
-				140C543D2A74F54B00CF1CB4 /* String+Regex.swift */,
+				140C543D2A74F54B00CF1CB4 /* String+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -921,7 +921,7 @@
 				143B270A2A76214500DFC0EE /* CreatePlaceView.swift in Sources */,
 				143B27022A761FCF00DFC0EE /* CreatePlaceFeature.swift in Sources */,
 				143B270C2A76245F00DFC0EE /* CreateDateView.swift in Sources */,
-				140C543E2A74F54B00CF1CB4 /* String+Regex.swift in Sources */,
+				140C543E2A74F54B00CF1CB4 /* String+.swift in Sources */,
 				143B27082A76200200DFC0EE /* CreateMemoFeature.swift in Sources */,
 				2BA345A72A6EB6BF00B7E2BD /* BaggleColor.swift in Sources */,
 				14E506542A6B8ED3008D5778 /* SignUpSuccessView.swift in Sources */,

--- a/Baggle/Baggle/Core/Common/Extensions/Date/Date+.swift
+++ b/Baggle/Baggle/Core/Common/Extensions/Date/Date+.swift
@@ -131,23 +131,31 @@ extension Date {
         return hoursFromNow
     }
 
+    // n 분 이후 생성
+    func later(minutes: Int) -> Date {
+        // swiftlint:disable:next force_unwrapping
+        let hoursFromNow = Calendar.current.date(byAdding: .minute, value: minutes, to: self)!
+        return hoursFromNow
+    }
+
     /// 약속 생성 가능 시간 리턴
     /// ex
     /// 2시 03분 -> 2시 05분
     /// 2시 05분 -> 2시 10분
     func meetingStartTime() -> Date {
+
         // 2시간 이후
-        var result = later(hours: 2)
+        let twoHoursLater = self.later(hours: 2)
 
-        // 2시 5분이면 생성이 불가능 -> 2시 6분으로
-        result.minute += 1
+        // 5분 이후
+        var twoHoursFiveMinutesLater = twoHoursLater.later(minutes: 5)
 
-        // 2시 10분으로
-        while result.minute % 5 != 0 {
-            result.minute += 1
+        // 5분 단위로 만들기
+        while twoHoursFiveMinutesLater.minute % 5 != 0 {
+            twoHoursFiveMinutesLater.minute -= 1
         }
 
-        return result
+        return twoHoursFiveMinutesLater
     }
 
     var canMeeting: Bool {

--- a/Baggle/Baggle/Core/Common/Extensions/String+.swift
+++ b/Baggle/Baggle/Core/Common/Extensions/String+.swift
@@ -7,10 +7,16 @@
 
 import Foundation
 
-// String 정규식 검사
-
 extension String {
+
+    // MARK: - String 정규식 검사
+
     func isValidRegex(regex: String) -> Bool {
         return self.range(of: regex, options: .regularExpression) != nil
+    }
+
+    // MARK: - 맨 마지막 문자 줄바꿈일 때 제거
+    func removeTrailingNewlines() -> String {
+        return self.filter { $0 != "\n" }
     }
 }

--- a/Baggle/Baggle/DesignSystem/View/Text/BaggleTextFeature.swift
+++ b/Baggle/Baggle/DesignSystem/View/Text/BaggleTextFeature.swift
@@ -46,7 +46,8 @@ struct BaggleTextFeature: ReducerProtocol {
                     state.errorMessage = nil
                 }
 
-                state.text = String(newText.prefix(state.maxCount))
+                let noNewLinesText = newText.removeTrailingNewlines()
+                state.text = String(noNewLinesText.prefix(state.maxCount))
 
                 return .none
 

--- a/Baggle/Baggle/DesignSystem/View/Text/BaggleTextFeature.swift
+++ b/Baggle/Baggle/DesignSystem/View/Text/BaggleTextFeature.swift
@@ -46,11 +46,7 @@ struct BaggleTextFeature: ReducerProtocol {
                     state.errorMessage = nil
                 }
 
-                if newText.count > state.maxCount {
-                    state.text = String(newText.prefix(state.maxCount))
-                } else {
-                    state.text = newText
-                }
+                state.text = String(newText.prefix(state.maxCount))
 
                 return .none
 

--- a/Baggle/Baggle/DesignSystem/View/Text/TextEditor/BaggleTextEditor.swift
+++ b/Baggle/Baggle/DesignSystem/View/Text/TextEditor/BaggleTextEditor.swift
@@ -12,7 +12,7 @@ import ComposableArchitecture
 struct BaggleTextEditor: View {
 
     private let store: StoreOf<BaggleTextFeature>
-    private var placeholder: String
+    @State private var placeholder: String
     private var title: TextFieldTitle
 
     init(
@@ -43,25 +43,37 @@ struct BaggleTextEditor: View {
 
                 // MARK: - 본문
 
-                VStack(alignment: .trailing) {
-                    TextEditor(
-                        text: viewStore.binding(
-                            get: \.text,
-                            send: BaggleTextFeature.Action.textChanged
+                ZStack(alignment: .bottomTrailing) {
+
+                    ZStack(alignment: .topLeading) {
+                        TextEditor(
+                            text: viewStore.binding(
+                                get: \.text,
+                                send: BaggleTextFeature.Action.textChanged
+                            )
                         )
-                    )
-                    .foregroundColor(viewStore.textFieldState.fgColor)
-                    .lineSpacing(5)
-                    .padding([.horizontal, .top])
-                    .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: 100)
-                    .focused($isFocused)
-                    .onChange(of: isFocused) { newValue in
-                        viewStore.send(.isFocused(newValue))
+                        .foregroundColor(viewStore.textFieldState.fgColor)
+                        .background(.clear)
+                        .lineSpacing(5)
+                        .padding()
+                        .focused($isFocused)
+                        .onChange(of: isFocused) { newValue in
+                            viewStore.send(.isFocused(newValue))
+                        }
+
+                        if viewStore.text.isEmpty && !isFocused {
+                            TextEditor(text: $placeholder)
+                                .font(.body)
+                                .foregroundColor(.gray)
+                                .disabled(true)
+                                .padding()
+                        }
                     }
+                    .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: 140)
 
                     Text("\(viewStore.text.count) / 50")
                         .foregroundColor(viewStore.textFieldState.fgColor)
-                        .padding([.bottom, .trailing])
+                        .padding()
                 }
                 .cornerRadius(10)
                 .overlay(

--- a/Baggle/Baggle/DesignSystem/View/Text/TextEditor/BaggleTextEditor.swift
+++ b/Baggle/Baggle/DesignSystem/View/Text/TextEditor/BaggleTextEditor.swift
@@ -37,7 +37,7 @@ struct BaggleTextEditor: View {
                 if case let .title(title) = title {
                     Text(title)
                         .font(.caption)
-                        .padding(.horizontal, 2)
+                        .padding(.horizontal, 4)
                         .padding(.bottom, 6)
                 }
 
@@ -60,7 +60,7 @@ struct BaggleTextEditor: View {
                     }
 
                     Text("\(viewStore.text.count) / 50")
-                        .foregroundColor(viewStore.textFieldState.borderColor)
+                        .foregroundColor(viewStore.textFieldState.fgColor)
                         .padding([.bottom, .trailing])
                 }
                 .cornerRadius(10)

--- a/Baggle/Baggle/DesignSystem/View/Text/TextEditor/BaggleTextEditor.swift
+++ b/Baggle/Baggle/DesignSystem/View/Text/TextEditor/BaggleTextEditor.swift
@@ -79,7 +79,6 @@ struct BaggleTextEditor: View {
                         .foregroundColor(viewStore.textFieldState.fgColor)
                 }
             }
-            .padding()
             .onAppear {
                 isFocused = viewStore.state.isFocused
             }

--- a/Baggle/Baggle/DesignSystem/View/Text/TextEditor/BaggleTextEditor.swift
+++ b/Baggle/Baggle/DesignSystem/View/Text/TextEditor/BaggleTextEditor.swift
@@ -50,6 +50,7 @@ struct BaggleTextEditor: View {
                             send: BaggleTextFeature.Action.textChanged
                         )
                     )
+                    .foregroundColor(viewStore.textFieldState.fgColor)
                     .lineSpacing(5)
                     .padding([.horizontal, .top])
                     .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: 100)

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Common/CreateDescription.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Common/CreateDescription.swift
@@ -1,0 +1,38 @@
+//
+//  CreateDescription.swift
+//  Baggle
+//
+//  Created by youtak on 2023/08/03.
+//
+
+import SwiftUI
+
+struct CreateDescription: View {
+
+    let createStatus: CreateStatus
+    let title: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+
+            PageIndicator(data: CreateStatus.data, selectedStatus: createStatus)
+                .padding(.vertical, 8)
+
+            HStack {
+                Text(title)
+                    .font(.title2)
+                Spacer()
+            }
+            .padding(.vertical, 12)
+        }
+    }
+}
+
+struct CreateDescription_Previews: PreviewProvider {
+    static var previews: some View {
+        CreateDescription(
+            createStatus: .title,
+            title: "친구들과 약속을 잡아보세요!"
+        )
+    }
+}

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Date/CreateDateView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Date/CreateDateView.swift
@@ -19,60 +19,60 @@ struct CreateDateView: View {
     var body: some View {
 
         WithViewStore(self.store, observe: { $0 }) { viewStore in
-            VStack(alignment: .leading, spacing: 16) {
 
-                PageIndicator(data: CreateStatus.data, selectedStatus: .date)
+            VStack(spacing: 0) {
 
-                Text("언제 만나기로 했나요?")
-                    .font(.title)
-                    .padding(.vertical, 5)
-                    .padding(.horizontal, 2)
-
-                Text("날짜와 시간을 입력하세요.")
-                    .padding(.horizontal, 2)
+                CreateDescription(createStatus: .date, title: "언제 만나기로 했나요?")
 
                 GeometryReader { proxy in
-                    HStack(spacing: dateButtonSpace) {
+                    VStack(alignment: .leading) {
 
-                        HStack {
-                            Text(viewStore.meetingDate.koreanDate())
-                            Spacer()
-                        }
-                        .foregroundColor(viewStore.dateButtonStatus.color)
-                        .padding()
-                        .frame(width: (proxy.size.width - dateButtonSpace) * dateWidthRatio)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 10)
-                                .stroke(viewStore.dateButtonStatus.color, lineWidth: 1)
-                        )
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            viewStore.send(.selectDateButtonTapped)
+                        Text("날짜와 시간을 입력하세요.")
+                            .padding(.horizontal, 2)
+
+                        HStack(spacing: dateButtonSpace) {
+
+                            HStack {
+                                Text(viewStore.meetingDate.koreanDate())
+                                Spacer()
+                            }
+                            .foregroundColor(viewStore.dateButtonStatus.color)
+                            .padding()
+                            .frame(width: (proxy.size.width - dateButtonSpace) * dateWidthRatio)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(viewStore.dateButtonStatus.color, lineWidth: 1)
+                            )
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                viewStore.send(.selectDateButtonTapped)
+                            }
+
+                            HStack {
+                                Text(viewStore.meetingDate.hourMinute())
+                                Spacer()
+                            }
+                            .foregroundColor(viewStore.timeButtonStatus.color)
+                            .padding()
+                            .frame(
+                                width: (proxy.size.width - dateButtonSpace) * (1 - dateWidthRatio)
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(viewStore.timeButtonStatus.color, lineWidth: 1)
+                            )
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                viewStore.send(.selectTimeButtonTapped)
+                            }
                         }
 
-                        HStack {
-                            Text(viewStore.meetingDate.hourMinute())
-                            Spacer()
-                        }
-                        .foregroundColor(viewStore.timeButtonStatus.color)
-                        .padding()
-                        .frame(width: (proxy.size.width - dateButtonSpace) * (1 - dateWidthRatio))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 10)
-                                .stroke(viewStore.timeButtonStatus.color, lineWidth: 1)
-                        )
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            viewStore.send(.selectTimeButtonTapped)
+                        if let errorMessage = viewStore.errorMessage {
+                            Text(errorMessage)
+                                .foregroundColor(.red)
+                                .padding(.horizontal, 2)
                         }
                     }
-                }
-                .frame(height: 52)
-
-                if let errorMessage = viewStore.errorMessage {
-                    Text(errorMessage)
-                        .foregroundColor(.red)
-                        .padding(.horizontal, 2)
                 }
 
                 Spacer()
@@ -82,6 +82,7 @@ struct CreateDateView: View {
                 } label: {
                     Text("다음")
                 }
+                .padding(.bottom, 10)
                 .buttonStyle(BagglePrimaryStyle())
                 .disabled(viewStore.buttonDisabled)
             }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Date/CreateDateView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Date/CreateDateView.swift
@@ -13,6 +13,7 @@ struct CreateDateView: View {
 
     private let dateButtonSpace: CGFloat = 10
     private let dateWidthRatio = 0.65
+    private let dateButtonHeight:CGFloat = 54
 
     let store: StoreOf<CreateDateFeature>
 
@@ -38,7 +39,9 @@ struct CreateDateView: View {
                             }
                             .foregroundColor(viewStore.dateButtonStatus.color)
                             .padding()
-                            .frame(width: (proxy.size.width - dateButtonSpace) * dateWidthRatio)
+                            .frame(
+                                width: abs(proxy.size.width - dateButtonSpace) * dateWidthRatio
+                            )
                             .overlay(
                                 RoundedRectangle(cornerRadius: 10)
                                     .stroke(viewStore.dateButtonStatus.color, lineWidth: 1)
@@ -55,7 +58,7 @@ struct CreateDateView: View {
                             .foregroundColor(viewStore.timeButtonStatus.color)
                             .padding()
                             .frame(
-                                width: (proxy.size.width - dateButtonSpace) * (1 - dateWidthRatio)
+                                width: abs(proxy.size.width - dateButtonSpace) * (1 - dateWidthRatio)
                             )
                             .overlay(
                                 RoundedRectangle(cornerRadius: 10)

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Date/CreateDateView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Date/CreateDateView.swift
@@ -85,7 +85,6 @@ struct CreateDateView: View {
                 } label: {
                     Text("다음")
                 }
-                .padding(.bottom, 10)
                 .buttonStyle(BagglePrimaryStyle())
                 .disabled(viewStore.buttonDisabled)
             }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoFeature.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoFeature.swift
@@ -13,8 +13,7 @@ struct CreateMemoFeature: ReducerProtocol {
         // Child
         var textEditorState = BaggleTextFeature.State(
             maxCount: 50,
-            textFieldState: .inactive,
-            isFocused: true
+            textFieldState: .inactive
         )
     }
 

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoView.swift
@@ -38,6 +38,7 @@ struct CreateMemoView: View {
                 .padding(.bottom, 10)
                 .buttonStyle(BagglePrimaryStyle())
             }
+            .contentShape(Rectangle())
             .onTapGesture {
                 hideKeyboard()
             }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoView.swift
@@ -18,18 +18,7 @@ struct CreateMemoView: View {
         WithViewStore(self.store, observe: { $0 }) { viewStore in
             VStack(spacing: 0) {
 
-                VStack(alignment: .leading, spacing: 16) {
-                    PageIndicator(data: CreateStatus.data, selectedStatus: .memo)
-
-                    HStack {
-                        Text("약속 메모를 남겨보세요.")
-                            .font(.title2)
-
-                        Spacer()
-                    }
-                }
-                .padding(.horizontal)
-                .padding(.top)
+                CreateDescription(createStatus: .memo, title: "약속 메모를 남겨보세요.")
 
                 BaggleTextEditor(
                     store: self.store.scope(
@@ -53,6 +42,7 @@ struct CreateMemoView: View {
                 hideKeyboard()
             }
         }
+        .padding()
     }
 }
 

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoView.swift
@@ -16,12 +16,20 @@ struct CreateMemoView: View {
     var body: some View {
 
         WithViewStore(self.store, observe: { $0 }) { viewStore in
-            Text("메모를 입력하세요")
-                .font(.largeTitle)
+            VStack(spacing: 0) {
 
-            VStack {
-                Text("메모를 입력하세요")
-                    .font(.largeTitle)
+                VStack(alignment: .leading, spacing: 16) {
+                    PageIndicator(data: CreateStatus.data, selectedStatus: .memo)
+
+                    HStack {
+                        Text("약속 메모를 남겨보세요.")
+                            .font(.title2)
+
+                        Spacer()
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.top)
 
                 BaggleTextEditor(
                     store: self.store.scope(

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoView.swift
@@ -35,7 +35,6 @@ struct CreateMemoView: View {
                 } label: {
                     Text("다음")
                 }
-                .padding(.bottom, 10)
                 .buttonStyle(BagglePrimaryStyle())
             }
             .contentShape(Rectangle())

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Place/CreatePlaceView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Place/CreatePlaceView.swift
@@ -16,28 +16,22 @@ struct CreatePlaceView: View {
     var body: some View {
 
         WithViewStore(self.store, observe: { $0 }) { viewStore in
-            VStack {
-                VStack(alignment: .leading, spacing: 16) {
+            VStack(spacing: 0) {
 
-                    PageIndicator(data: CreateStatus.data, selectedStatus: .place)
+                CreateDescription(createStatus: .place, title: "약속 장소는 어디인가요?")
 
-                    Text("약속 장소는 어디인가요?")
-                        .font(.title2)
-
-                    BaggleTextField(
-                        store: self.store.scope(
-                            state: \.textFieldState,
-                            action: CreatePlaceFeature.Action.textFieldAction
-                        ),
-                        placeholder: "ex. 성수역 2번 출구",
-                        title: .title("약속 장소를 입력하세요.")
-                    )
-                    .submitLabel(.done)
-                    .onSubmit {
-                        viewStore.send(.submitButtonTapped)
-                    }
+                BaggleTextField(
+                    store: self.store.scope(
+                        state: \.textFieldState,
+                        action: CreatePlaceFeature.Action.textFieldAction
+                    ),
+                    placeholder: "ex. 성수역 2번 출구",
+                    title: .title("약속 장소를 입력하세요.")
+                )
+                .submitLabel(.done)
+                .onSubmit {
+                    viewStore.send(.submitButtonTapped)
                 }
-                .padding()
 
                 Spacer()
 
@@ -50,6 +44,7 @@ struct CreatePlaceView: View {
                 .buttonStyle(BagglePrimaryStyle())
                 .disabled(viewStore.state.nextButtonDisabled)
             }
+            .padding()
             .contentShape(Rectangle())
             .onTapGesture {
                 hideKeyboard()

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Place/CreatePlaceView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Place/CreatePlaceView.swift
@@ -40,7 +40,6 @@ struct CreatePlaceView: View {
                 } label: {
                     Text("다음")
                 }
-                .padding(.bottom, 10)
                 .buttonStyle(BagglePrimaryStyle())
                 .disabled(viewStore.state.nextButtonDisabled)
             }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Success/CreateSuccessFeature.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Success/CreateSuccessFeature.swift
@@ -5,7 +5,12 @@
 //  Created by youtak on 2023/07/31.
 //
 
+import SwiftUI
+
 import ComposableArchitecture
+import KakaoSDKCommon
+import KakaoSDKShare
+import KakaoSDKTemplate
 
 struct CreateSuccessFeature: ReducerProtocol {
 
@@ -15,7 +20,8 @@ struct CreateSuccessFeature: ReducerProtocol {
 
     enum Action: Equatable {
 
-        case completeButtonTapped
+        case kakaoInviteButtonTapped
+        case sendLaterButtonTapped
 
         // MARK: - Delegate
         case delegate(Delegate)
@@ -24,6 +30,10 @@ struct CreateSuccessFeature: ReducerProtocol {
             case moveToHome
         }
     }
+
+    @Environment(\.openURL) private var openURL
+
+    @Dependency(\.sendInvitation) private var sendInvitation
 
     var body: some ReducerProtocolOf<Self> {
 
@@ -35,12 +45,32 @@ struct CreateSuccessFeature: ReducerProtocol {
 
             switch action {
 
-            case .completeButtonTapped:
+            case .kakaoInviteButtonTapped:
+                return .run { send in
+                    if ShareApi.isKakaoTalkSharingAvailable() {
+                        if let url = await sendInvitation(name: "집들이집들", id: 1000) {
+                            openURL(url)
+                        } else {
+                            // 실패
+                        }
+                    } else {
+                        moveToAppStore()
+                    }
+                }
+
+            case .sendLaterButtonTapped:
                 return .run { send in await send(.delegate(.moveToHome)) }
 
             case .delegate(.moveToHome):
                 return .none
             }
+        }
+    }
+
+    @Sendable func moveToAppStore() {
+        let url = "itms-apps://itunes.apple.com/app/362057947"
+        if let url = URL(string: url) {
+            openURL(url)
         }
     }
 }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Success/CreateSuccessView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Success/CreateSuccessView.swift
@@ -82,14 +82,14 @@ struct CreateSuccessView: View {
                 // MARK: - 버튼
 
                 Button {
-                    viewStore.send(.completeButtonTapped)
+                    viewStore.send(.kakaoInviteButtonTapped)
                 } label: {
                     Text("카카오톡으로 초대장 보내기")
                 }
                 .buttonStyle(BagglePrimaryStyle())
 
                 Button {
-                    viewStore.send(.completeButtonTapped)
+                    viewStore.send(.sendLaterButtonTapped)
                 } label: {
                     Text("나중에 보내기")
                         .foregroundColor(Color.gray)

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Success/CreateSuccessView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Success/CreateSuccessView.swift
@@ -16,19 +16,87 @@ struct CreateSuccessView: View {
     var body: some View {
 
         WithViewStore(self.store, observe: { $0 }) { viewStore in
-            VStack {
-                Text("모임 생성이 완료됐어요!")
-                    .font(.largeTitle)
+            VStack(spacing: 0) {
+
+                // MARK: - 설명
+
+                VStack {
+                    Text("약속이 만들어졌어요!")
+                        .font(.title)
+                        .padding(.vertical, 8)
+
+                    VStack(spacing: 6) {
+                        Text("카톡으로 친구들에게 초대장을 보내고")
+
+                        Text("특별한 추억을 만들어보세요")
+                    }
+                    .foregroundColor(Color.gray)
+                }
+                .padding(.top, 44) // 툴바 높이
+                .padding(.top, 8)
+
+                // MARK: - 모임 설명
+
+                HStack {
+                    VStack(alignment: .leading, spacing: 12) {
+
+                        Text("수빈님네 집들이")
+                            .font(.title3)
+
+                        VStack(alignment: .leading, spacing: 8) {
+
+                            HStack {
+                                Text("장소 | ")
+                                    .foregroundColor(Color.gray)
+                                Text("유탁님 없는 잠실")
+                            }
+
+                            HStack {
+                                Text("시간 | ")
+                                    .foregroundColor(Color.gray)
+                                Text("2023년 10월 25일 15:30")
+                            }
+                        }
+                    }
+                    .padding(.vertical, 28)
+                    .padding(.horizontal, 20)
+
+                    Spacer()
+                }
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(.blue, lineWidth: 1)
+                }
+                .padding(.vertical, 30)
+                .padding(.horizontal, 20)
+
+                // MARK: - 이미지
+
+                Image(systemName: "envelope")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 200, height: 200)
 
                 Spacer()
+
+                // MARK: - 버튼
 
                 Button {
                     viewStore.send(.completeButtonTapped)
                 } label: {
-                    Text("완료")
+                    Text("카카오톡으로 초대장 보내기")
                 }
                 .buttonStyle(BagglePrimaryStyle())
+
+                Button {
+                    viewStore.send(.completeButtonTapped)
+                } label: {
+                    Text("나중에 보내기")
+                        .foregroundColor(Color.gray)
+                }
+                .padding()
             }
+            .padding(.horizontal)
             .toolbar(.hidden, for: .navigationBar)
         }
     }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleView.swift
@@ -44,7 +44,6 @@ struct CreateTitleView: View {
                     } label: {
                         Text("다음")
                     }
-                    .padding(.bottom, 10)
                     .buttonStyle(BagglePrimaryStyle())
                     .disabled(viewStore.state.nextButtonDisabled)
                 }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleView.swift
@@ -20,28 +20,22 @@ struct CreateTitleView: View {
             action: { .path($0)})
         ) {
             WithViewStore(self.store, observe: { $0 }) { viewStore in
-                VStack {
-                    VStack(alignment: .leading, spacing: 16) {
+                VStack(spacing: 0) {
 
-                        PageIndicator(data: CreateStatus.data, selectedStatus: .title)
+                    CreateDescription(createStatus: .title, title: "친구들과 약속을 잡아보세요!")
 
-                        Text("친구들과 약속을 잡아보세요!")
-                            .font(.title2)
-
-                        BaggleTextField(
-                            store: self.store.scope(
-                                state: \.textFieldState,
-                                action: CreateTitleFeature.Action.textFieldAction
-                            ),
-                            placeholder: "ex. 바글이와 저녁 약속",
-                            title: .title("어떤 약속인가요?")
-                        )
-                        .submitLabel(.done)
-                        .onSubmit {
-                            viewStore.send(.submitButtonTapped)
-                        }
+                    BaggleTextField(
+                        store: self.store.scope(
+                            state: \.textFieldState,
+                            action: CreateTitleFeature.Action.textFieldAction
+                        ),
+                        placeholder: "ex. 바글이와 저녁 약속",
+                        title: .title("어떤 약속인가요?")
+                    )
+                    .submitLabel(.done)
+                    .onSubmit {
+                        viewStore.send(.submitButtonTapped)
                     }
-                    .padding()
 
                     Spacer()
 
@@ -54,6 +48,7 @@ struct CreateTitleView: View {
                     .buttonStyle(BagglePrimaryStyle())
                     .disabled(viewStore.state.nextButtonDisabled)
                 }
+                .padding()
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button("취소") {

--- a/Baggle/BaggleTests/BaggleDateTests.swift
+++ b/Baggle/BaggleTests/BaggleDateTests.swift
@@ -113,4 +113,70 @@ final class BaggleDateTests: XCTestCase {
 
         XCTAssertEqual(result, "18:10")
     }
+
+    // 시각 : 2023년 8월 31일 21시 57분
+    // 약속 생성 가능 시각 : 2023년 9월 1일 0시 0분
+    // 테스트 결과값 : "2023년 9월 2일"
+    func test_약속가능시간_생성_날짜_04() throws {
+        let date = try createDate(2023, 8, 31, 21, 57)
+        let meetingDate = date.meetingStartTime()
+        let result = meetingDate.koreanDate()
+
+        XCTAssertEqual(result, "2023년 9월 1일")
+    }
+
+    // 시각 : 2023년 8월 31일 21시 57분
+    // 약속 생성 가능 시각 : 2023년 9월 1일 0시 0분
+    // 테스트 결과값 : "0:00"
+    func test_약속가능시간_생성_시간_04() throws {
+        let date = try createDate(2023, 8, 31, 21, 57)
+        let meetingDate = date.meetingStartTime()
+        let result = meetingDate.hourMinute()
+
+        XCTAssertEqual(result, "00:00")
+    }
+
+    // 시각 : 2023년 12월 31일 21시 57분
+    // 약속 생성 가능 시각 : 2024년 1월 1일 0시 0분
+    // 테스트 결과값 : "2024년 1월 1일"
+    func test_약속가능시간_생성_날짜_05() throws {
+        let date = try createDate(2023, 12, 31, 21, 57)
+        let meetingDate = date.meetingStartTime()
+        let result = meetingDate.koreanDate()
+
+        XCTAssertEqual(result, "2024년 1월 1일")
+    }
+
+    // 시각 : 2023년 12월 31일 21시 57분
+    // 약속 생성 가능 시각 : 2024년 1월 1일 0시 0분
+    // 테스트 결과값 : "0:00"
+    func test_약속가능시간_생성_시간_05() throws {
+        let date = try createDate(2024, 12, 31, 21, 57)
+        let meetingDate = date.meetingStartTime()
+        let result = meetingDate.hourMinute()
+
+        XCTAssertEqual(result, "00:00")
+    }
+
+    // 시각 : 2024년 2월 28일 23시 00분
+    // 약속 생성 가능 시각 : 2024년 2월 29일 1시 5분
+    // 테스트 결과값 : "2024년 2월 29일"
+    func test_약속가능시간_생성_날짜_06() throws {
+        let date = try createDate(2024, 2, 28, 23, 00)
+        let meetingDate = date.meetingStartTime()
+        let result = meetingDate.koreanDate()
+
+        XCTAssertEqual(result, "2024년 2월 29일")
+    }
+
+    // 시각 : 2024년 2월 28일 23시 00분
+    // 약속 생성 가능 시각 : 2024년 2월 29일 1시 5분
+    // 테스트 결과값 : "01:05"
+    func test_약속가능시간_생성_시간_06() throws {
+        let date = try createDate(2024, 2, 28, 23, 00)
+        let meetingDate = date.meetingStartTime()
+        let result = meetingDate.hourMinute()
+
+        XCTAssertEqual(result, "01:05")
+    }
 }


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #57 

## 내용
<!--
로직 설명  
--> 
- 모임 생성 View의 통일성을 위해 `CreateDescription` View를 만들었습니다. 화면 Indicator와 제목을 관리합니다.
- 모임 생성 성공 View를 구현했습니다. 수정 권한이 없어 디자인 픽셀을 정확히는 적용하지는 못해 추후 소소한 수정이 있을 것 같습니다. 이미지는 목업 이미지 사용했습니다.
- 모임 생성 날짜 로직을 수정했습니다. 기존 로직의 경우 while문에서 `result.minute += 1`를 사용했는데, minute이 59까지만 가능해 정각을 만들지 못하고 무한 루프에 빠졌습니다. 현재 시간에 2시간 5분을 더하고, 분(minute)을 빼면서 가장 가까운 5분 단위를 찾아줬습니다.
  - 테스트 케이스 추가하고 성공 확인했습니다.
- TextEditor에 PlaceHolder 추가했습니다. ZStack을 사용해서 TextEditor 2개를 겹쳐주었습니다. `Text()`로도 해봤는데 터치문제, TextEditor의 글자와 위치가 정확히 겹치지 않는 등의 문제가 있어 TextEditor 2개를 사용했습니다.
- TextEditor 입력시 줄바꿈 문자를 제거합니다. 붙여넣기의 경우를 생각해서 filter문으로 전체탐색 합니다. TextField는 자체적으로 줄바꿈 문자를 자동으로 스페이스로 변환해주더라구요.
- 모임 생성 성공 이후 버튼 이벤트 처리했습니다.

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

![Simulator Screen Recording - iPhone 14 Pro - 2023-08-03 at 15 35 40](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/341c1225-d794-4e3f-950d-b9b22325e716)

비디오로 올릴라 했는데 용량이 커서 안 되네요... 

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- View 완성인줄 알았는데 디자인이 조금 수정되었네요. PR 생성해서 수정하겠습니다.

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
- TextEditor Placeholder 참고 : https://stackoverflow.com/questions/62741851/how-to-add-placeholder-text-to-texteditor-in-swiftui

