### PR TITLE
Fix - MainTabView NavigationStack 수정

### DIFF
--- a/Baggle/Baggle/Features/JoinMeeting/JoinMeetingFeature.swift
+++ b/Baggle/Baggle/Features/JoinMeeting/JoinMeetingFeature.swift
@@ -49,7 +49,9 @@ struct JoinMeetingFeature: ReducerProtocol {
                 let id = state.meetingId
                 return .run { _ in
                     await self.dismiss()
-                    postObserverAction(.moveMeetingDetail, object: id)
+                    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now()+0.1) {
+                        postObserverAction(.moveMeetingDetail, object: id)
+                    }
                 }
 
             case .joinFailed:

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -120,15 +120,16 @@ struct MeetingDetailFeature: ReducerProtocol {
             case .selectOwner:
                 return .none
 
-            case .delegate(let action):
-                switch action {
-                case .deleteSuccess:
-                    state.isAlertPresented = false
-                    state.dismiss = true
-                    return .none
-                case .onDisappear:
-                    return .none
-                }
+            case .delegate(.deleteSuccess):
+                state.isAlertPresented = false
+                state.dismiss = true
+                return .none
+
+            case .delegate(.onDisappear):
+                return .none
+
+            case .delegate:
+                return .none
             }
         }
         .ifLet(\.$selectOwner, action: /Action.selectOwner) {

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
@@ -13,6 +13,8 @@ struct MeetingDetailView: View {
 
     let store: StoreOf<MeetingDetailFeature>
 
+    @Environment(\.dismiss) private var dismiss
+
     var body: some View {
 
         WithViewStore(self.store, observe: { $0 }) { viewStore in
@@ -20,6 +22,8 @@ struct MeetingDetailView: View {
                 VStack(spacing: 20) {
                     Text("모임 생성")
                         .font(.title)
+
+                    Text("id: \(viewStore.meetingId)")
 
                     if let data = viewStore.meetingData {
                         Text("모임명: \(data.name), 모임 id: \(data.id)")
@@ -31,7 +35,6 @@ struct MeetingDetailView: View {
                         }
 
                         Button("방장 넘기기") {
-                            print("방장 넘기기 alert")
                             viewStore.send(.leaveButtonTapped)
                         }
                     }
@@ -61,10 +64,11 @@ struct MeetingDetailView: View {
                     .presentationDetents([.height(340)])
                     .presentationDragIndicator(.visible)
             }
-            .onAppear {
-                viewStore.send(.onAppear)
-            }
-            .toolbar(.hidden, for: .tabBar)
+            .onAppear { viewStore.send(.onAppear) }
+            .onDisappear { viewStore.send(.delegate(.onDisappear)) }
+            .onChange(of: viewStore.dismiss, perform: { _ in
+                dismiss()
+            })
         }
     }
 }

--- a/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
@@ -53,7 +53,7 @@ struct HomeFeature: ReducerProtocol {
         // 모임 상세
 
         case meetingDetailAction(MeetingDetailFeature.Action)
-        case setMeetingDetailId(Int)
+        case pushToMeetingDetail(Int)
         case pushMeetingDetail
     }
 
@@ -139,7 +139,7 @@ struct HomeFeature: ReducerProtocol {
                 print("초대하기 실패")
                 return .none
 
-            case .setMeetingDetailId(let id):
+            case .pushToMeetingDetail(let id):
                 state.meetingDetailId = id
                 state.meetingDetailState = MeetingDetailFeature.State(meetingId: id)
                 return .run { send in

--- a/Baggle/Baggle/Features/Tab/Home/HomeView.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeView.swift
@@ -86,25 +86,22 @@ struct HomeView: View {
                                perform: { noti in
                         // noti로부터 id 값 받아서 넣기
                         if let id = noti.object as? Int {
-                            viewStore.send(.moveToMeetingDetail(id))
+                            viewStore.send(.setMeetingDetailId(id))
                         }
                     })
                     .onAppear {
                         viewStore.send(.onAppear)
                     }
-                    // 푸시알림 탭해서 들어오는 경우
+                    // 외부에서 들어오는 경우 (카카오톡, 푸시알림)
                     .navigationDestination(
                         isPresented: Binding(
-                            get: { viewStore.pushMeetingDetailId != nil },
-                            set: { _ in
-                                viewStore.send(.moveToMeetingDetail(
-                                    viewStore.pushMeetingDetailId ?? 0))
-                            })
+                            get: { viewStore.pushMeetingDetail },
+                            set: { _ in viewStore.send(.pushMeetingDetail) })
                     ) {
                         MeetingDetailView(
                             store: Store(
                                 initialState: MeetingDetailFeature.State(
-                                    meetingId: viewStore.pushMeetingDetailId ?? 0),
+                                    meetingId: viewStore.meetingDetailId ?? 0),
                                 reducer: MeetingDetailFeature()
                             )
                         )

--- a/Baggle/Baggle/Features/Tab/Home/HomeView.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeView.swift
@@ -58,9 +58,8 @@ struct HomeView: View {
 
                         Spacer()
                     }
-                    .background(Color.red)
                     .onTapGesture {
-                        viewStore.send(.setMeetingDetailId(meeting.id))
+                        viewStore.send(.pushToMeetingDetail(meeting.id))
                     }
                 }
 
@@ -87,7 +86,7 @@ struct HomeView: View {
                        perform: { noti in
                 // noti로부터 id 값 받아서 넣기
                 if let id = noti.object as? Int {
-                    viewStore.send(.setMeetingDetailId(id))
+                    viewStore.send(.pushToMeetingDetail(id))
                 }
             })
             .onAppear {

--- a/Baggle/Baggle/Features/Tab/Home/HomeView.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeView.swift
@@ -14,102 +14,96 @@ struct HomeView: View {
     let store: StoreOf<HomeFeature>
 
     var body: some View {
-        NavigationStackStore(self.store.scope(
-            state: \.path,
-            action: { .path($0) })) {
-                WithViewStore(self.store, observe: { $0 }) { viewStore in
-                    VStack(spacing: 10) {
-                        Text("Home View")
-                            .padding()
+        WithViewStore(self.store, observe: { $0 }) { viewStore in
+            VStack(spacing: 10) {
+                Text("Home View")
+                    .padding()
 
-                        Button {
-                            viewStore.send(.shareButtonTapped)
-                        } label: {
-                            Text("카카오톡 공유하기")
-                        }
-                        .buttonStyle(BagglePrimaryStyle())
+                Button {
+                    viewStore.send(.shareButtonTapped)
+                } label: {
+                    Text("카카오톡 공유하기")
+                }
+                .buttonStyle(BagglePrimaryStyle())
 
-                        HStack(spacing: 20) {
-                            Button {
-                                viewStore.send(.changeMeetingStatus(.ongoing))
-                            } label: {
-                                Text("진행중인 모임")
-                            }
-
-                            Button {
-                                viewStore.send(.changeMeetingStatus(.complete))
-                            } label: {
-                                Text("지난 모임")
-                            }
-
-                            Button {
-                                viewStore.send(.refreshMeetingList)
-                            } label: {
-                                Text("모임 리프레시")
-                            }
-                        }
-                        .padding()
-
-                        List((viewStore.meetingStatus == .ongoing)
-                             ? viewStore.ongoingList : viewStore.completedList) { meeting in
-                            NavigationLink(state: MeetingDetailFeature.State(
-                                meetingId: meeting.id)
-                            ) {
-                                VStack(alignment: .leading, spacing: 10) {
-                                    Text("\(meeting.id)")
-                                        .font(.caption)
-                                    Text(meeting.name)
-                                }
-                            }
-                        }
-
-                        HStack(spacing: 20) {
-                            Button {
-                                viewStore.send(.fetchMeetingList(.ongoing))
-                            } label: {
-                                Text("진행중인 모임 업데이트")
-                            }
-
-                            Button {
-                                viewStore.send(.fetchMeetingList(.complete))
-                            } label: {
-                                Text("지난 모임 업데이트")
-                            }
-                        }
-                        .padding()
+                HStack(spacing: 20) {
+                    Button {
+                        viewStore.send(.changeMeetingStatus(.ongoing))
+                    } label: {
+                        Text("진행중인 모임")
                     }
-                    .onReceive(NotificationCenter.default.publisher(for: .refreshMeetingList),
-                               perform: { _ in
+
+                    Button {
+                        viewStore.send(.changeMeetingStatus(.complete))
+                    } label: {
+                        Text("지난 모임")
+                    }
+
+                    Button {
                         viewStore.send(.refreshMeetingList)
-                    })
-                    .onReceive(NotificationCenter.default.publisher(for: .moveMeetingDetail),
-                               perform: { noti in
-                        // noti로부터 id 값 받아서 넣기
-                        if let id = noti.object as? Int {
-                            viewStore.send(.setMeetingDetailId(id))
-                        }
-                    })
-                    .onAppear {
-                        viewStore.send(.onAppear)
-                    }
-                    // 외부에서 들어오는 경우 (카카오톡, 푸시알림)
-                    .navigationDestination(
-                        isPresented: Binding(
-                            get: { viewStore.pushMeetingDetail },
-                            set: { _ in viewStore.send(.pushMeetingDetail) })
-                    ) {
-                        MeetingDetailView(
-                            store: Store(
-                                initialState: MeetingDetailFeature.State(
-                                    meetingId: viewStore.meetingDetailId ?? 0),
-                                reducer: MeetingDetailFeature()
-                            )
-                        )
+                    } label: {
+                        Text("모임 리프레시")
                     }
                 }
-            } destination: { store in
-                MeetingDetailView(store: store)
+                .padding()
+
+                List((viewStore.meetingStatus == .ongoing)
+                     ? viewStore.ongoingList : viewStore.completedList) { meeting in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 10) {
+                            Text("\(meeting.id)")
+                                .font(.caption)
+                            Text(meeting.name)
+                        }
+
+                        Spacer()
+                    }
+                    .background(Color.red)
+                    .onTapGesture {
+                        viewStore.send(.setMeetingDetailId(meeting.id))
+                    }
+                }
+
+                HStack(spacing: 20) {
+                    Button {
+                        viewStore.send(.fetchMeetingList(.ongoing))
+                    } label: {
+                        Text("진행중인 모임 업데이트")
+                    }
+
+                    Button {
+                        viewStore.send(.fetchMeetingList(.complete))
+                    } label: {
+                        Text("지난 모임 업데이트")
+                    }
+                }
+                .padding()
             }
+            .onReceive(NotificationCenter.default.publisher(for: .refreshMeetingList),
+                       perform: { _ in
+                viewStore.send(.refreshMeetingList)
+            })
+            .onReceive(NotificationCenter.default.publisher(for: .moveMeetingDetail),
+                       perform: { noti in
+                // noti로부터 id 값 받아서 넣기
+                if let id = noti.object as? Int {
+                    viewStore.send(.setMeetingDetailId(id))
+                }
+            })
+            .onAppear {
+                viewStore.send(.onAppear)
+            }
+            .navigationDestination(
+                isPresented: Binding(
+                    get: { viewStore.pushMeetingDetail },
+                    set: { _ in viewStore.send(.pushMeetingDetail) })
+            ) {
+                MeetingDetailView(
+                    store: self.store.scope(
+                        state: \.meetingDetailState,
+                        action: HomeFeature.Action.meetingDetailAction))
+            }
+        }
     }
 }
 

--- a/Baggle/Baggle/Features/Tab/MainTab/MainTabView.swift
+++ b/Baggle/Baggle/Features/Tab/MainTab/MainTabView.swift
@@ -81,7 +81,7 @@ struct MainTabView: View {
                             // 모임 참여 여부 확인 후 분기처리
                             // 모임 참여 중 > 모임 상세로 이동
 //                            postObserverAction(.moveMeetingDetail, object: id)
-                            
+
                             // 모임 참여 전 > 모임 정보 확인
                             viewStore.send(.moveToJoinMeeting(id))
                         }

--- a/Baggle/Baggle/Features/Tab/MainTab/MainTabView.swift
+++ b/Baggle/Baggle/Features/Tab/MainTab/MainTabView.swift
@@ -16,8 +16,7 @@ struct MainTabView: View {
     var body: some View {
 
         WithViewStore(self.store, observe: { $0 }) { viewStore in
-            // 수정 예정
-//            NavigationStack {
+            NavigationStack {
                 TabView(
                     selection: viewStore.binding(
                         get: \.selectedTab,
@@ -82,7 +81,7 @@ struct MainTabView: View {
                         viewStore.send(.moveToJoinMeeting(id))
                     }
                 }
-//            }
+            }
         }
     }
 }

--- a/Baggle/Baggle/Features/Tab/MainTab/MainTabView.swift
+++ b/Baggle/Baggle/Features/Tab/MainTab/MainTabView.swift
@@ -73,12 +73,18 @@ struct MainTabView: View {
                     if let id = url.params()?["id"] as? String,
                        let id = Int(id) {
                         print("MainTabView - id: \(id)")
-                        // 모임 참여 여부 확인 후 분기처리
-                        // 모임 참여 중 > 모임 상세로 이동
-//                        postObserverAction(.moveMeetingDetail, object: id)
 
-                        // 모임 참여 전 > 모임 정보 확인
-                        viewStore.send(.moveToJoinMeeting(id))
+                        let delay = (viewStore.selectedTab == .createMeeting) ? 0.2 : 0
+                        let dispatchTime: DispatchTime = DispatchTime.now() + delay
+
+                        DispatchQueue.main.asyncAfter(deadline: dispatchTime) {
+                            // 모임 참여 여부 확인 후 분기처리
+                            // 모임 참여 중 > 모임 상세로 이동
+//                            postObserverAction(.moveMeetingDetail, object: id)
+                            
+                            // 모임 참여 전 > 모임 정보 확인
+                            viewStore.send(.moveToJoinMeeting(id))
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
close #58 

## 내용
<!--
로직 설명  
--> 
- MainTabView에서 `NavigationStack` 사용해서 탭바 내부에서 푸시하는 경우 하단 탭바 안보이도록 수정
- HomeView의 NavigationStackStore 제거, `delegate`로 이벤트 연결
- HomeView의 NavigationLink 대신 `onTapGesture` 사용 수정
  - 외부(카카오톡, 푸시알림)에서 들어오는 경우 navigationDestination을 사용해야 하는데, 
리스트 내에서는 NavigationLink를 사용하게되면 navigationDestination에서 사용하는 pushMeetingDetail 같은 변수들이 꼬이는 문제가 생겼습니다. 
  - 변수가 통일되도록 `navigationDestination`으로 화면 전환 방식을 통일했습니다.
- 모임 생성 중 외부에서 들어오는 경우, 모임 생성 모달이 내리기 전에 MainTabView에서 모임 참여 모달을 띄우는 문제를 막기 위해 `딜레이` 추가

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

|  탭 전환(refresh) | 홈에서 모임 참여  |  모임 생성에서 모임 참여 | 푸시알림 받고 모임 상세 |
|--|--|--|--|
| ![ezgif com-resize (22)](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/6b4f3432-9c4a-4220-990c-9878d55fa223) |  ![ezgif com-resize (23)](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/caa5b1da-494a-4030-9b12-4e544078687b) |   ![ezgif com-resize (24)](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/f1e638ed-5544-4802-859a-79c9ac9c1f89)   |   ![ezgif com-resize (25)](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/a61a1126-629f-4f14-8304-d1601a2e5a4a) |


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
