### PR TITLE
Feature - BaggleAlert 타입, BaggleSecondaryStyle 추가

### DIFF
--- a/Baggle/Baggle/DesignSystem/View/Alert/BaggleAlert.swift
+++ b/Baggle/Baggle/DesignSystem/View/Alert/BaggleAlert.swift
@@ -38,6 +38,11 @@ import ComposableArchitecture
  
  */
 
+enum AlertButton {
+    case onebutton
+    case twobutton
+}
+
 struct BaggleAlert: View {
 
     private let screenSize: CGRect = UIScreen.main.bounds
@@ -47,16 +52,18 @@ struct BaggleAlert: View {
 
     @Binding var isPresented: Bool
 
-    private let rightButtonAction: () -> Void
     private var title: String
     private var description: String?
+    private var alertButton: AlertButton
     private var leftButtonTitle: String
     private var rightButtonTitle: String
+    private let rightButtonAction: () -> Void
 
     init(
         isPresented: Binding<Bool>,
         title: String,
         description: String? = nil,
+        alertType: AlertButton = .twobutton,
         leftButtonTitle: String = "취소",
         rightButtonTitle: String = "네",
         rightButtonAction: @escaping () -> Void
@@ -64,6 +71,7 @@ struct BaggleAlert: View {
         self._isPresented = isPresented
         self.title = title
         self.description = description
+        self.alertButton = alertType
         self.leftButtonTitle = leftButtonTitle
         self.rightButtonTitle = rightButtonTitle
         self.rightButtonAction = rightButtonAction
@@ -73,30 +81,31 @@ struct BaggleAlert: View {
         ZStack {
             ShadeView(isPresented: $isPresented)
 
-            VStack(spacing: 20) {
-                Spacer()
+            VStack(spacing: 40) {
 
-                Text(title)
-                    .font(.body)
-                    .multilineTextAlignment(.center)
+                VStack(spacing: 2) {
+                    Text(title)
+                        .font(.system(size: 20))
+                        .padding(.vertical, 5)
 
-                if let description {
-                    Text(description)
-                        .multilineTextAlignment(.center)
-                        .font(.caption)
-                        .foregroundColor(.gray)
-                } else {
-                    Spacer()
+                    if let description {
+                        Text(description)
+                            .font(.system(size: 16))
+                            .foregroundColor(.gray)
+                            .padding(.vertical, 4)
+                    }
                 }
+                .multilineTextAlignment(.center)
 
                 HStack {
-                    Button {
-                        isPresented.toggle()
-                    } label: {
-                        Text(leftButtonTitle)
-                            .font(.body)
-                            .foregroundColor(.black)
-                            .frame(width: alertWidth/2, height: 52)
+                    if alertButton == .twobutton {
+                        Button {
+                            isPresented.toggle()
+                        } label: {
+                            Text(leftButtonTitle)
+                                .frame(width: alertWidth/2, height: 52)
+                        }
+                        .buttonStyle(BagglePrimaryStyle(size: .small))
                     }
 
                     Button {
@@ -104,17 +113,17 @@ struct BaggleAlert: View {
                         isPresented.toggle()
                     } label: {
                         Text(rightButtonTitle)
-                            .font(.body)
-                            .foregroundColor(.red)
                             .frame(width: alertWidth/2, height: 52)
                     }
+                    .buttonStyle(alertButton == .onebutton
+                                 ? BagglePrimaryStyle(size: .medium) :
+                                    BagglePrimaryStyle(size: .small))
                 }
-                .frame(width: alertWidth, height: 52)
+                .frame(width: alertWidth, height: 54)
             }
-            .padding()
+            .padding(.top, 52)
+            .padding(.bottom, 20)
             .frame(width: alertWidth)
-            .frame(minHeight: screenSize.height * 0.2,
-                   maxHeight: screenSize.height * 0.24)
             .background(.white)
             .cornerRadius(20)
             .opacity(self.isPresented ? 1 : 0)

--- a/Baggle/Baggle/DesignSystem/View/Button/BaggleButtonStyle.swift
+++ b/Baggle/Baggle/DesignSystem/View/Button/BaggleButtonStyle.swift
@@ -72,10 +72,47 @@ struct BagglePrimaryStyle: ButtonStyle {
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .frame(width: UIScreen.main.bounds.width * size.ratio, height: 62)
+            .frame(width: UIScreen.main.bounds.width * size.ratio, height: 54)
             .foregroundColor(foregroundColor(configuration.isPressed))
             .background(backgroundColor(configuration.isPressed))
             .cornerRadius(shape.radius)
-            .shadow(color: Color(.systemGray4).opacity(0.6), radius: 4)
+    }
+}
+
+struct BaggleSecondaryStyle: ButtonStyle {
+
+    private let foregroundColor: Color = .white
+    private let backgroundColor: Color = .black
+
+    @Environment(\.isEnabled) private var isEnabled
+
+    private func foregroundColor(_ isPressed: Bool) -> Color {
+        if !isEnabled {
+            return foregroundColor
+        } else if isPressed {
+            return foregroundColor.opacity(0.5)
+        } else {
+            return foregroundColor
+        }
+    }
+
+    private func backgroundColor(_ isPressed: Bool) -> Color {
+        if !isEnabled {
+            return Color.gray // 디자인 확정 시 수정
+        } else if isPressed {
+            return backgroundColor.opacity(0.5)
+        } else {
+            return backgroundColor
+        }
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(height: 54)
+            .padding(.leading, 34)
+            .padding(.trailing, 36)
+            .foregroundColor(foregroundColor(configuration.isPressed))
+            .background(backgroundColor(configuration.isPressed))
+            .cornerRadius(54/2)
     }
 }

--- a/Baggle/Baggle/DesignSystem/View/Button/BaggleButtonType.swift
+++ b/Baggle/Baggle/DesignSystem/View/Button/BaggleButtonType.swift
@@ -15,7 +15,7 @@ enum ButtonSize {
 
     var ratio: CGFloat {
         switch self {
-        case .small: return 0.5
+        case .small: return 0.4
         case .medium: return 0.79
         case .large: return 0.89
         }

--- a/Baggle/Baggle/DesignSystem/View/Button/BaggleButtonType.swift
+++ b/Baggle/Baggle/DesignSystem/View/Button/BaggleButtonType.swift
@@ -16,8 +16,8 @@ enum ButtonSize {
     var ratio: CGFloat {
         switch self {
         case .small: return 0.5
-        case .medium: return 0.7
-        case .large: return 0.9
+        case .medium: return 0.79
+        case .large: return 0.89
         }
     }
 }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Date/CreateDateView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Date/CreateDateView.swift
@@ -13,7 +13,7 @@ struct CreateDateView: View {
 
     private let dateButtonSpace: CGFloat = 10
     private let dateWidthRatio = 0.65
-    private let dateButtonHeight:CGFloat = 54
+    private let dateButtonHeight: CGFloat = 54
 
     let store: StoreOf<CreateDateFeature>
 

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Success/CreateSuccessFeature.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Success/CreateSuccessFeature.swift
@@ -46,7 +46,7 @@ struct CreateSuccessFeature: ReducerProtocol {
             switch action {
 
             case .kakaoInviteButtonTapped:
-                return .run { send in
+                return .run { _ in
                     if ShareApi.isKakaoTalkSharingAvailable() {
                         if let url = await sendInvitation(name: "집들이집들", id: 1000) {
                             openURL(url)

--- a/Baggle/Baggle/Features/Tab/Home/HomeView.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeView.swift
@@ -25,9 +25,13 @@ struct HomeView: View {
                         Button {
                             viewStore.send(.shareButtonTapped)
                         } label: {
-                            Text("카카오톡 공유하기")
+                            HStack(spacing: 8) {
+                                Image(systemName: "paperplane")
+
+                                Text("카카오톡 공유하기")
+                            }
                         }
-                        .buttonStyle(BagglePrimaryStyle())
+                        .buttonStyle(BaggleSecondaryStyle())
 
                         HStack(spacing: 20) {
                             Button {


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
close #69 

## 내용
<!--
로직 설명  
--> 
- BaggleSecondaryStyle 추가
- BaggleAlert - AlertType(onebutton, twobutton) 추가

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 
| 버튼 1개 alert | 버튼 2개 alert | BaggleSecondaryStyle |
|--|--|--|
| ![버튼 1개](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/35c00aac-1a2f-44f4-b785-b67305b78d44) |  ![버튼 2개](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/813754fb-a099-46dd-a0ee-10623c8357cb) | ![IMG_0217E1F77DC2-1](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/d9457685-818e-4138-a633-a547b48501e9) |



## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
BagglePrimaryStyle과 BaggleSecondaryStyle 네이밍을 좀 더 역할에 맞게 수정하면 좋을 것 같은데, 어떤가요?
- 생각해본거로는 기능에 따라 기본 버튼을 BaggleBasicStyle, 
모임 상세에서 쓰이는 버튼을 BaggleEventStyle, BaggleTriggerStyle, BaggleActionStyle.. 
요런 식으로 했는데 더 나은거 있으면 추천해주세요!

+ 디자인 확정 전에라 ButtonSize = .small은 임의로 비율 잡았습니다

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
