### PR TITLE
회원 가입 화면 디자인 수정 & 키보드 올라올 때 View 이동

### DIFF
--- a/Baggle/Baggle/Features/Login/SignUp/Main/Components/ProfileImageView.swift
+++ b/Baggle/Baggle/Features/Login/SignUp/Main/Components/ProfileImageView.swift
@@ -11,19 +11,33 @@ struct ProfileImageView: View {
     let imageState: AlbumImageState
 
     var body: some View {
-        switch imageState {
-        case .empty:
-            Image(systemName: "plus")
-                .font(.system(size: 40))
+        ZStack {
+            switch imageState {
+            case .empty:
+                ZStack {}
+            case .loading:
+                ProgressView()
+            case .success(let image):
+                image.resizable()
+            case .failure:
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 40))
+                    .foregroundColor(.red)
+            }
+        }
+        .scaledToFill()
+        .clipShape(Circle())
+        .frame(width: 160, height: 160)
+        .background {
+            Circle()
+                .tint(Color.gray.opacity(0.2))
+        }
+        .overlay(alignment: .bottomTrailing) {
+            Image(systemName: "camera.circle.fill")
+                .symbolRenderingMode(.multicolor)
+                .font(.system(size: 30))
                 .foregroundColor(.blue)
-        case .loading:
-            ProgressView()
-        case .success(let image):
-            image.resizable()
-        case .failure:
-            Image(systemName: "exclamationmark.triangle.fill")
-                .font(.system(size: 40))
-                .foregroundColor(.red)
+                .offset(x: -8, y: -8)
         }
     }
 }

--- a/Baggle/Baggle/Features/Login/SignUp/Main/SignUpFeature.swift
+++ b/Baggle/Baggle/Features/Login/SignUp/Main/SignUpFeature.swift
@@ -18,6 +18,7 @@ struct SignUpFeature: ReducerProtocol {
 
         var disableDismissAnimation: Bool = false
         var isLoading: Bool = false
+        var keyboardAppear: Bool = false
 
         // MARK: - 이미지
 
@@ -58,6 +59,7 @@ struct SignUpFeature: ReducerProtocol {
         // MARK: - Nickname
 
         case textFieldAction(BaggleTextFeature.Action)
+        case keyboardAppear
 
         // MARK: - Network
 
@@ -158,7 +160,14 @@ struct SignUpFeature: ReducerProtocol {
 
                 // MARK: - Nickname TextField
 
+            case .textFieldAction(.isFocused):
+                return .run { send in await send(.keyboardAppear) }
+
             case .textFieldAction:
+                return .none
+
+            case .keyboardAppear:
+                state.keyboardAppear.toggle()
                 return .none
 
                 // MARK: - Network

--- a/Baggle/Baggle/Features/Login/SignUp/Main/SignUpView.swift
+++ b/Baggle/Baggle/Features/Login/SignUp/Main/SignUpView.swift
@@ -5,6 +5,7 @@
 //  Created by youtak on 2023/07/22.
 //
 
+import Combine
 import PhotosUI
 import SwiftUI
 
@@ -15,6 +16,7 @@ struct SignUpView: View {
     private typealias SignUpViewStore = ViewStore<SignUpFeature.State, SignUpFeature.Action>
 
     let store: StoreOf<SignUpFeature>
+    let scrollBottomID: String = "scrollBottomID"
 
     var body: some View {
 
@@ -32,23 +34,26 @@ struct SignUpView: View {
 
                     VStack {
 
-                        ScrollView {
+                        ScrollViewReader { scrollProxy in
+                            ScrollView {
 
-                            VStack {
-                                description
+                                VStack {
+                                    description
 
-                                Spacer()
+                                    photoPicker(viewStore: viewStore)
 
-                                photoPicker(viewStore: viewStore)
-                                    .padding()
-
-                                nicknameTextField(viewStore: viewStore)
-
-                                Spacer()
-                                Spacer()
-                                Spacer()
+                                    nicknameTextField(viewStore: viewStore)
+                                        .id(scrollBottomID)
+                                }
+                                .padding()
                             }
-                            .padding()
+                            .onChange(of: viewStore.keyboardAppear) { _ in
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                                    withAnimation {
+                                        scrollProxy.scrollTo(scrollBottomID)
+                                    }
+                                }
+                            }
                         }
 
                         nextButton(viewStore: viewStore)
@@ -102,6 +107,7 @@ extension SignUpView {
 
             Spacer()
         }
+        .padding(.vertical, 12)
     }
 
     @ViewBuilder
@@ -125,6 +131,7 @@ extension SignUpView {
                         .tint(Color.gray.opacity(0.2))
                 }
         }
+        .padding(.top, 40)
     }
 
     @ViewBuilder
@@ -137,6 +144,7 @@ extension SignUpView {
             ),
             placeholder: "닉네임 (한, 영, 숫자, _, -, 2-8자)"
         )
+        .padding(.vertical, 50)
     }
 
     @ViewBuilder

--- a/Baggle/Baggle/Features/Login/SignUp/Main/SignUpView.swift
+++ b/Baggle/Baggle/Features/Login/SignUp/Main/SignUpView.swift
@@ -97,8 +97,6 @@ extension SignUpView {
     private var description: some View {
         HStack {
             VStack(alignment: .leading) {
-                Text("안녕하세요!")
-
                 Text("Baggle에서 쓸 프로필을")
 
                 Text("설정해주세요.")
@@ -123,13 +121,6 @@ extension SignUpView {
             photoLibrary: .shared()
         ) {
             ProfileImageView(imageState: viewStore.imageState)
-                .scaledToFill()
-                .clipShape(Circle())
-                .frame(width: 160, height: 160)
-                .background {
-                    Circle()
-                        .tint(Color.gray.opacity(0.2))
-                }
         }
         .padding(.top, 40)
     }

--- a/Baggle/Baggle/Sources/BaggleApp.swift
+++ b/Baggle/Baggle/Sources/BaggleApp.swift
@@ -26,7 +26,7 @@ struct BaggleApp: App {
             AppView(
                 store: Store(
                     initialState: AppFeature.State(
-                        isLoggedIn: true,
+                        isLoggedIn: false,
                         loginFeature: LoginFeature.State(),
                         mainTabFeature: MainTabFeature.State(
                             selectedTab: .home,


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #62 
- #76 

## 내용
<!--
로직 설명  
--> 
- 디자인에 따른 회원 가입 화면 View 수정했습니다. 
- ScrollViewReader를 사용해 키보드가 올라오면 스크롤을 바닥으로 이동시킵니다. 이 때 키보드가 올라온 걸 인식하는 시간이 필요해 지연 실행합니다.

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- 키보드 올라온 상태에서 이미지를 클릭할 때 키보드를 내리고 싶은데 방법을 고민 중입니다. TextField의 FocusState를 밖에서 사용할 수 있도록 Binding으로 바꿔줄지 고민 중 입니다. 의견 있으면 말씀해주세요.

![Simulator Screen Recording - iPhone 14 Pro - 2023-08-05 at 14 49 51](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/f1f5d168-c0ff-4e69-aba7-8d6d16b35fca)


## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
