### PR TITLE
Feature - HomeView UI

### DIFF
--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		2B5BE6AF2A779C8E00F25474 /* MeetingDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5BE6AE2A779C8E00F25474 /* MeetingDetail.swift */; };
 		2B5BE6B22A77A40900F25474 /* MeetingDetailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5BE6B12A77A40900F25474 /* MeetingDetailService.swift */; };
 		2B5CF2682A6EC889004D3033 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5CF2672A6EC889004D3033 /* View+.swift */; };
+		2B604DDA2A7F60E7000E2DE2 /* CircleProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B604DD92A7F60E7000E2DE2 /* CircleProfileView.swift */; };
 		2B84696A2A6E7AE200D75D32 /* BaggleAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B84695F2A6E7AE200D75D32 /* BaggleAlert.swift */; };
 		2B84696B2A6E7AE200D75D32 /* BaggleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8469612A6E7AE200D75D32 /* BaggleTextField.swift */; };
 		2B84696C2A6E7AE200D75D32 /* BaggleTextFieldType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8469622A6E7AE200D75D32 /* BaggleTextFieldType.swift */; };
@@ -99,6 +100,7 @@
 		2BABCB2D2A76D1AF00AFECA3 /* MeetingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BABCB2B2A76D1AF00AFECA3 /* MeetingDetailView.swift */; };
 		2BCACB7F2A742C9000892D45 /* BaggleTextFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BCACB7E2A742C9000892D45 /* BaggleTextFeature.swift */; };
 		2BD5D5572A6C4EBE0070C196 /* View+Modifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD5D5562A6C4EBE0070C196 /* View+Modifier.swift */; };
+		2BE5299E2A7D697800A53779 /* MeetingListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE5299D2A7D697800A53779 /* MeetingListCell.swift */; };
 		2BE74F622A7771B700402068 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2BE74F612A7771B600402068 /* GoogleService-Info.plist */; };
 		2BF268202A77828100F32ADF /* Meeting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF2681F2A77828100F32ADF /* Meeting.swift */; };
 		2BF268232A77861300F32ADF /* HomeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF268222A77861300F32ADF /* HomeService.swift */; };
@@ -187,6 +189,7 @@
 		2B5BE6AE2A779C8E00F25474 /* MeetingDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDetail.swift; sourceTree = "<group>"; };
 		2B5BE6B12A77A40900F25474 /* MeetingDetailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDetailService.swift; sourceTree = "<group>"; };
 		2B5CF2672A6EC889004D3033 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
+		2B604DD92A7F60E7000E2DE2 /* CircleProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleProfileView.swift; sourceTree = "<group>"; };
 		2B84695F2A6E7AE200D75D32 /* BaggleAlert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaggleAlert.swift; sourceTree = "<group>"; };
 		2B8469612A6E7AE200D75D32 /* BaggleTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaggleTextField.swift; sourceTree = "<group>"; };
 		2B8469622A6E7AE200D75D32 /* BaggleTextFieldType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaggleTextFieldType.swift; sourceTree = "<group>"; };
@@ -206,6 +209,7 @@
 		2BABCB2B2A76D1AF00AFECA3 /* MeetingDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeetingDetailView.swift; sourceTree = "<group>"; };
 		2BCACB7E2A742C9000892D45 /* BaggleTextFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggleTextFeature.swift; sourceTree = "<group>"; };
 		2BD5D5562A6C4EBE0070C196 /* View+Modifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Modifier.swift"; sourceTree = "<group>"; };
+		2BE5299D2A7D697800A53779 /* MeetingListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingListCell.swift; sourceTree = "<group>"; };
 		2BE74F612A7771B600402068 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		2BF2681F2A77828100F32ADF /* Meeting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Meeting.swift; sourceTree = "<group>"; };
 		2BF268222A77861300F32ADF /* HomeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeService.swift; sourceTree = "<group>"; };
@@ -687,6 +691,8 @@
 			children = (
 				2B308B8E2A7CCE5A00B9846F /* SegmentedTagView.swift */,
 				2B308B902A7CDA1400B9846F /* SegmentedPickerView.swift */,
+				2BE5299D2A7D697800A53779 /* MeetingListCell.swift */,
+				2B604DD92A7F60E7000E2DE2 /* CircleProfileView.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -994,6 +1000,7 @@
 				146C51E92A793D3F00FF3142 /* BaggleDatePickerView.swift in Sources */,
 				2B84696C2A6E7AE200D75D32 /* BaggleTextFieldType.swift in Sources */,
 				146C51F02A79429E00FF3142 /* SelectDateView.swift in Sources */,
+				2BE5299E2A7D697800A53779 /* MeetingListCell.swift in Sources */,
 				14B7A0412A753D4800B8E202 /* SignUpService.swift in Sources */,
 				1461B6022A7BA8C500A15706 /* RoundedTriangle.swift in Sources */,
 				14E5064E2A6B88F7008D5778 /* SignUpView.swift in Sources */,
@@ -1020,6 +1027,7 @@
 				2B308B8F2A7CCE5A00B9846F /* SegmentedTagView.swift in Sources */,
 				14E4C4B72A6E43CA008643D9 /* CreateTitleFeature.swift in Sources */,
 				2B86CBC02A70F00900800B02 /* HomeFeature.swift in Sources */,
+				2B604DDA2A7F60E7000E2DE2 /* CircleProfileView.swift in Sources */,
 				2BF268232A77861300F32ADF /* HomeService.swift in Sources */,
 				140E88112A64B626005119F8 /* BaggleApp.swift in Sources */,
 				14F7B0962A7BABC30068B1E4 /* BubbleType.swift in Sources */,

--- a/Baggle/Baggle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Baggle/Baggle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -30,7 +30,7 @@
     {
       "identity" : "firebase-ios-sdk",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
         "revision" : "a580250a9ff49ec38da5430cef20f88ddc831db2",
         "version" : "10.12.0"

--- a/Baggle/Baggle/Core/Models/Meeting.swift
+++ b/Baggle/Baggle/Core/Models/Meeting.swift
@@ -14,7 +14,7 @@ struct Meeting: Equatable, Identifiable {
     let place: String // 장소
     let date: String // 날짜
     let time: String // 시간
-    let dday: Int?
+    let dDay: Int
     let profileImages: [String] // 프로필 이미지
     let status: MeetingStatus
     let isConfirmed: Bool // 약속 확정 여부

--- a/Baggle/Baggle/Core/Models/Meeting.swift
+++ b/Baggle/Baggle/Core/Models/Meeting.swift
@@ -14,7 +14,9 @@ struct Meeting: Equatable, Identifiable {
     let place: String // 장소
     let date: String // 날짜
     let time: String // 시간
+    let dday: Int?
     let profileImages: [String] // 프로필 이미지
+    let status: MeetingStatus
     let isConfirmed: Bool // 약속 확정 여부
 
     static func == (lhs: Meeting, rhs: Meeting) -> Bool {

--- a/Baggle/Baggle/Core/Services/Home/HomeService.swift
+++ b/Baggle/Baggle/Core/Services/Home/HomeService.swift
@@ -47,7 +47,7 @@ struct MockUpMeetingService {
                 place: "우리집",
                 date: "2023년 04월 22일",
                 time: "15:30",
-                dday: 0,
+                dDay: 0,
                 profileImages: [
                     "https://avatars.githubusercontent.com/u/71167956?s=64&v=4",
                     "https://avatars.githubusercontent.com/u/81167570?s=64&v=4",
@@ -61,7 +61,7 @@ struct MockUpMeetingService {
                 place: "남의 집",
                 date: "2023년 08년 23일",
                 time: "15:30",
-                dday: 30,
+                dDay: 30,
                 profileImages: [
                     "https://avatars.githubusercontent.com/u/81167570?s=64&v=4",
                     "https://avatars.githubusercontent.com/u/71776532?s=64&v=4"
@@ -77,7 +77,7 @@ struct MockUpMeetingService {
                 place: "우리집",
                 date: "2023년 04월 22일",
                 time: "15:30",
-                dday: nil,
+                dDay: -10,
                 profileImages: [
                     "https://avatars.githubusercontent.com/u/71167956?s=64&v=4",
                     "https://avatars.githubusercontent.com/u/81167570?s=64&v=4",

--- a/Baggle/Baggle/Core/Services/Home/HomeService.swift
+++ b/Baggle/Baggle/Core/Services/Home/HomeService.swift
@@ -47,22 +47,26 @@ struct MockUpMeetingService {
                 place: "우리집",
                 date: "2023년 04월 22일",
                 time: "15:30",
+                dday: 0,
                 profileImages: [
                     "https://avatars.githubusercontent.com/u/71167956?s=64&v=4",
                     "https://avatars.githubusercontent.com/u/81167570?s=64&v=4",
                     "https://avatars.githubusercontent.com/u/71776532?s=64&v=4"
                 ],
-                isConfirmed: false),
+                status: .dday,
+                isConfirmed: true),
             Meeting(
                 id: Int.random(in: 101...200),
                 name: "진행 중인 모임2",
                 place: "남의 집",
                 date: "2023년 08년 23일",
                 time: "15:30",
+                dday: 30,
                 profileImages: [
                     "https://avatars.githubusercontent.com/u/81167570?s=64&v=4",
                     "https://avatars.githubusercontent.com/u/71776532?s=64&v=4"
                 ],
+                status: .ongoing,
                 isConfirmed: false)
         ]
 
@@ -73,12 +77,14 @@ struct MockUpMeetingService {
                 place: "우리집",
                 date: "2023년 04월 22일",
                 time: "15:30",
+                dday: nil,
                 profileImages: [
                     "https://avatars.githubusercontent.com/u/71167956?s=64&v=4",
                     "https://avatars.githubusercontent.com/u/81167570?s=64&v=4",
                     "https://avatars.githubusercontent.com/u/71776532?s=64&v=4"
                 ],
-                isConfirmed: false)
+                status: .complete,
+                isConfirmed: true)
         ]
         return type == .ongoing ? ongoing : complete
     }

--- a/Baggle/Baggle/DesignSystem/View/Tag/BaggleColor.swift
+++ b/Baggle/Baggle/DesignSystem/View/Tag/BaggleColor.swift
@@ -14,15 +14,6 @@ enum BaggleColor {
     var bgColor: Color {
         switch self {
         case .blue:
-            return Color.blue.opacity(0.2)
-        case .pink:
-            return Color.pink.opacity(0.2)
-        }
-    }
-
-    var fgColor: Color {
-        switch self {
-        case .blue:
             return Color.blue
         case .pink:
             return Color.pink

--- a/Baggle/Baggle/DesignSystem/View/Tag/BaggleTag.swift
+++ b/Baggle/Baggle/DesignSystem/View/Tag/BaggleTag.swift
@@ -18,10 +18,11 @@ struct BaggleTag: View {
 
     var body: some View {
         Text(text)
+            .font(.system(size: 12, weight: .semibold))
             .kerning(-0.5)
-            .padding(.horizontal, 8)
+            .padding(.horizontal, 10)
             .padding(.vertical, 6)
-            .foregroundColor(color.fgColor)
+            .foregroundColor(.white)
             .background(color.bgColor)
             .cornerRadius(6)
     }
@@ -29,8 +30,10 @@ struct BaggleTag: View {
 
 struct BaggleTag_Previews: PreviewProvider {
     static var previews: some View {
-        BaggleTag("장소")
+        VStack {
+            BaggleTag("D-30")
 
-        BaggleTag("시간", .pink)
+            BaggleTag("D-Day", .pink)
+        }
     }
 }

--- a/Baggle/Baggle/Features/Tab/Home/Common/CircleProfileView.swift
+++ b/Baggle/Baggle/Features/Tab/Home/Common/CircleProfileView.swift
@@ -1,0 +1,63 @@
+//
+//  CircleProfileView.swift
+//  Baggle
+//
+//  Created by 양수빈 on 2023/08/06.
+//
+
+import SwiftUI
+
+enum ProfileSize {
+    case large // 홈, 본인 프로필 이미지
+    case medium // 모임 상세, 멤버 프로필 이미지 -> 추가 수정 필요
+    case small // 모임 상세, 피드 게시물 위 프로필 이미지
+    case extraSmall // 홈, 모임 리스트 내 멤버 프로필 이미지
+
+    var length: CGFloat {
+        switch self {
+        case .large: return 72
+        case .medium: return 64
+        case .extraSmall: return 24
+        case .small: return 32
+        }
+    }
+
+    var borderColor: Color {
+        switch self {
+        case .large: return .gray
+        case .medium: return .blue
+        case .extraSmall: return .gray
+        case .small: return .clear
+        }
+    }
+}
+
+struct CircleProfileView: View {
+    let imageUrl: String
+    let size: ProfileSize
+
+    var body: some View {
+
+        AsyncImage(url: URL(string: imageUrl)) { image in
+            image
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        } placeholder: {
+            Color.gray
+        }
+        .frame(width: size.length, height: size.length)
+        .clipShape(Circle())
+        .overlay {
+            Circle()
+                .stroke(size.borderColor, lineWidth: size == .medium ? 3 : 1)
+        }
+    }
+}
+
+struct CircleProfileView_Previews: PreviewProvider {
+    static var previews: some View {
+        CircleProfileView(imageUrl: "https://avatars.githubusercontent.com/u/81167570?v=4",
+                          size: .large)
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/Baggle/Baggle/Features/Tab/Home/Common/MeetingListCell.swift
+++ b/Baggle/Baggle/Features/Tab/Home/Common/MeetingListCell.swift
@@ -1,0 +1,124 @@
+//
+//  MeetingCellView.swift
+//  Baggle
+//
+//  Created by 양수빈 on 2023/08/05.
+//
+
+import SwiftUI
+
+struct MeetingListCell: View {
+
+    let meetingStatus: MeetingStatus
+    let data: Meeting
+
+    var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 8) {
+                    
+                    if meetingStatus == .dday {
+                        BaggleTag("D-Day", .pink)
+                    } else if meetingStatus == .ongoing {
+                        BaggleTag("D-30")
+                    }
+                    
+                    HStack(spacing: 4) {
+                        Text("📌")
+                        
+                        Text(data.name)
+                    }
+                    
+                    Text(attributedColorString(str: "장소  |  \(data.place)",
+                                               targetStr: "장소  |",
+                                               color: .black,
+                                               targetColor: .gray))
+                    .font(.system(size: 14))
+                    
+                    Text(attributedColorString(str: "시간  |  \(data.date) \(data.time)",
+                                               targetStr: "시간  |",
+                                               color: .black,
+                                               targetColor: .gray))
+                    .font(.system(size: 14))
+                }
+                
+                HStack {
+                    HStack(spacing: -4) {
+                        
+                        ForEach(data.profileImages, id: \.self) { _ in
+                            // 데이터 넣기
+                            CircleProfileView(
+                                imageUrl: "https://avatars.githubusercontent.com/u/81167570?v=4",
+                                size: .extraSmall)
+                        }
+                    }
+                    
+                    Spacer()
+                    
+                    Text("참여자 \(data.profileImages.count)명")
+                        .font(.system(size: 14))
+                }
+                
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 16)
+            .padding(.bottom, 20)
+            
+            // 디데이 + 한시간 전인 경우와 이미 지나서 확정된 경우
+            if data.isConfirmed {
+                // 스탬프로 이미지 변경
+                Image(systemName: "moon")
+                    .frame(width: 121, height: 89)
+                    .background(.black.opacity(0.4))
+                    .padding(.bottom, 12)
+                    .padding(.trailing, 12)
+            }
+            
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(meetingStatus.fgColor, lineWidth: 1)
+        }
+    }
+}
+
+struct MeetingCellView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 10) {
+            MeetingListCell(
+                meetingStatus: .dday,
+                data: Meeting(
+                    id: 1,
+                    name: "유탁님 없는 파티🔔",
+                    place: "유탁님 없는 잠실",
+                    date: "2023년 10월 23일",
+                    time: "15:30",
+                    profileImages: ["1", "2", "3", "4", "5", "6"],
+                    isConfirmed: true))
+
+            MeetingListCell(
+                meetingStatus: .ongoing,
+                data: Meeting(
+                    id: 1,
+                    name: "유탁님 없는 파티🔔",
+                    place: "유탁님 없는 잠실",
+                    date: "2023년 10월 23일",
+                    time: "15:30",
+                    profileImages: ["1", "2", "3", "4", "5", "6"],
+                    isConfirmed: false))
+
+            MeetingListCell(
+                meetingStatus: .complete,
+                data: Meeting(
+                    id: 1,
+                    name: "유탁님 없는 파티🔔",
+                    place: "유탁님 없는 잠실",
+                    date: "2023년 10월 23일",
+                    time: "15:30",
+                    profileImages: ["1", "2", "3", "4", "5", "6"],
+                    isConfirmed: true))
+        }
+        .padding()
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/Baggle/Baggle/Features/Tab/Home/Common/MeetingListCell.swift
+++ b/Baggle/Baggle/Features/Tab/Home/Common/MeetingListCell.swift
@@ -15,13 +15,11 @@ struct MeetingListCell: View {
         ZStack(alignment: .bottomTrailing) {
             VStack(alignment: .leading, spacing: 16) {
                 VStack(alignment: .leading, spacing: 8) {
-
-                    if let dday = data.dday {
-                        if dday == 0 {
-                            BaggleTag("D-Day", .pink)
-                        } else {
-                            BaggleTag("D-\(dday)")
-                        }
+                    
+                    if data.dDay == 0 {
+                        BaggleTag("D-Day", .pink)
+                    } else if data.dDay > 0 {
+                        BaggleTag("D-\(data.dDay)")
                     }
 
                     HStack(spacing: 4) {
@@ -91,7 +89,7 @@ struct MeetingCellView_Previews: PreviewProvider {
                     place: "유탁님 없는 잠실",
                     date: "2023년 10월 23일",
                     time: "15:30",
-                    dday: 0,
+                    dDay: 0,
                     profileImages: ["1", "2", "3", "4", "5", "6"],
                     status: .dday,
                     isConfirmed: true))
@@ -103,7 +101,7 @@ struct MeetingCellView_Previews: PreviewProvider {
                     place: "유탁님 없는 잠실",
                     date: "2023년 10월 23일",
                     time: "15:30",
-                    dday: 20,
+                    dDay: 20,
                     profileImages: ["1", "2", "3", "4", "5", "6"],
                     status: .ongoing,
                     isConfirmed: false))
@@ -115,7 +113,7 @@ struct MeetingCellView_Previews: PreviewProvider {
                     place: "유탁님 없는 잠실",
                     date: "2023년 10월 23일",
                     time: "15:30",
-                    dday: nil,
+                    dDay: -10,
                     profileImages: ["1", "2", "3", "4", "5", "6"],
                     status: .complete,
                     isConfirmed: true))

--- a/Baggle/Baggle/Features/Tab/Home/Common/MeetingListCell.swift
+++ b/Baggle/Baggle/Features/Tab/Home/Common/MeetingListCell.swift
@@ -9,42 +9,43 @@ import SwiftUI
 
 struct MeetingListCell: View {
 
-    let meetingStatus: MeetingStatus
     let data: Meeting
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
             VStack(alignment: .leading, spacing: 16) {
                 VStack(alignment: .leading, spacing: 8) {
-                    
-                    if meetingStatus == .dday {
-                        BaggleTag("D-Day", .pink)
-                    } else if meetingStatus == .ongoing {
-                        BaggleTag("D-30")
+
+                    if let dday = data.dday {
+                        if dday == 0 {
+                            BaggleTag("D-Day", .pink)
+                        } else {
+                            BaggleTag("D-\(dday)")
+                        }
                     }
-                    
+
                     HStack(spacing: 4) {
                         Text("📌")
-                        
+
                         Text(data.name)
                     }
-                    
+
                     Text(attributedColorString(str: "장소  |  \(data.place)",
                                                targetStr: "장소  |",
                                                color: .black,
                                                targetColor: .gray))
                     .font(.system(size: 14))
-                    
+
                     Text(attributedColorString(str: "시간  |  \(data.date) \(data.time)",
                                                targetStr: "시간  |",
                                                color: .black,
                                                targetColor: .gray))
                     .font(.system(size: 14))
                 }
-                
+
                 HStack {
                     HStack(spacing: -4) {
-                        
+
                         ForEach(data.profileImages, id: \.self) { _ in
                             // 데이터 넣기
                             CircleProfileView(
@@ -52,18 +53,17 @@ struct MeetingListCell: View {
                                 size: .extraSmall)
                         }
                     }
-                    
+
                     Spacer()
-                    
+
                     Text("참여자 \(data.profileImages.count)명")
                         .font(.system(size: 14))
                 }
-                
             }
             .padding(.horizontal, 20)
             .padding(.top, 16)
             .padding(.bottom, 20)
-            
+
             // 디데이 + 한시간 전인 경우와 이미 지나서 확정된 경우
             if data.isConfirmed {
                 // 스탬프로 이미지 변경
@@ -73,11 +73,10 @@ struct MeetingListCell: View {
                     .padding(.bottom, 12)
                     .padding(.trailing, 12)
             }
-            
         }
         .overlay {
             RoundedRectangle(cornerRadius: 12)
-                .stroke(meetingStatus.fgColor, lineWidth: 1)
+                .stroke(data.status.fgColor, lineWidth: 1)
         }
     }
 }
@@ -86,36 +85,39 @@ struct MeetingCellView_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 10) {
             MeetingListCell(
-                meetingStatus: .dday,
                 data: Meeting(
                     id: 1,
                     name: "유탁님 없는 파티🔔",
                     place: "유탁님 없는 잠실",
                     date: "2023년 10월 23일",
                     time: "15:30",
+                    dday: 0,
                     profileImages: ["1", "2", "3", "4", "5", "6"],
+                    status: .dday,
                     isConfirmed: true))
 
             MeetingListCell(
-                meetingStatus: .ongoing,
                 data: Meeting(
                     id: 1,
                     name: "유탁님 없는 파티🔔",
                     place: "유탁님 없는 잠실",
                     date: "2023년 10월 23일",
                     time: "15:30",
+                    dday: 20,
                     profileImages: ["1", "2", "3", "4", "5", "6"],
+                    status: .ongoing,
                     isConfirmed: false))
 
             MeetingListCell(
-                meetingStatus: .complete,
                 data: Meeting(
                     id: 1,
                     name: "유탁님 없는 파티🔔",
                     place: "유탁님 없는 잠실",
                     date: "2023년 10월 23일",
                     time: "15:30",
+                    dday: nil,
                     profileImages: ["1", "2", "3", "4", "5", "6"],
+                    status: .complete,
                     isConfirmed: true))
         }
         .padding()

--- a/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
@@ -15,12 +15,20 @@ import KakaoSDKTemplate
 
 enum MeetingStatus {
     case ongoing
+    case dday
     case complete
 
     var title: String {
         switch self {
-        case .ongoing: return "예정된 약속"
+        case .ongoing, .dday: return "예정된 약속"
         case .complete: return "지난 약속"
+        }
+    }
+
+    var fgColor: Color {
+        switch self {
+        case .ongoing, .complete: return .gray.opacity(0.5)
+        case .dday: return .pink
         }
     }
 }

--- a/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
@@ -48,6 +48,7 @@ struct HomeFeature: ReducerProtocol {
         var completedList: [Meeting] = []
         var meetingDetailState: MeetingDetailFeature.State = MeetingDetailFeature.State(
             meetingId: 0)
+        var isRefreshing: Bool = false
 
         @PresentationState var usingCamera: CameraFeature.State?
     }
@@ -110,12 +111,18 @@ struct HomeFeature: ReducerProtocol {
                 }
 
             case .refreshMeetingList:
+                state.isRefreshing = true
                 state.ongoingList.removeAll()
                 state.completedList.removeAll()
                 state.meetingStatus = .ongoing
                 return .run { send in
-                    let list = await meetingService.fetchMeetingList(.ongoing)
-                    await send(.updateMeetingList(.ongoing, list))
+                    do {
+                        try await Task.sleep(nanoseconds: 1_000_000_000)
+                        let list = await meetingService.fetchMeetingList(.ongoing)
+                        await send(.updateMeetingList(.ongoing, list))
+                    } catch {
+                        print("error")
+                    }
                 }
 
             case .changeMeetingStatus(let status):
@@ -135,6 +142,7 @@ struct HomeFeature: ReducerProtocol {
                         state.completedList.append(contentsOf: model)
                     }
                 }
+                state.isRefreshing = false
                 return .none
 
             case .shareButtonTapped:

--- a/Baggle/Baggle/Features/Tab/Home/HomeView.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeView.swift
@@ -20,7 +20,7 @@ struct HomeView: View {
                     // section 간의 간격을 없애기 위해 사용
                     VStack(spacing: 0) {
                         userHeader()
-                        
+
                         // sticky header
                         LazyVStack(pinnedViews: [.sectionHeaders]) {
                             Section(header: listHeader(viewStore: viewStore)) {
@@ -35,7 +35,7 @@ struct HomeView: View {
                                                     .font(.caption)
                                                 Text(meeting.name)
                                             }
-                                            
+
                                             Spacer()
                                         }
                                         .onTapGesture {
@@ -49,7 +49,7 @@ struct HomeView: View {
                     }
                 }
                 .clipped()
-                
+
                 // 임시 버튼
                 tempButton(viewStore: viewStore)
             }

--- a/Baggle/Baggle/Features/Tab/Home/HomeView.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeView.swift
@@ -24,26 +24,19 @@ struct HomeView: View {
                         // sticky header
                         LazyVStack(pinnedViews: [.sectionHeaders]) {
                             Section(header: listHeader(viewStore: viewStore)) {
-                                VStack(spacing: 0) {
+                                VStack(spacing: 12) {
                                     ForEach((viewStore.meetingStatus == .ongoing)
                                             ? viewStore.ongoingList : viewStore.completedList
                                     ) { meeting in
                                         // cell
-                                        HStack {
-                                            VStack(alignment: .leading, spacing: 10) {
-                                                Text("\(meeting.id)")
-                                                    .font(.caption)
-                                                Text(meeting.name)
+                                        MeetingListCell(data: meeting)
+                                            .onTapGesture {
+                                                viewStore.send(.pushToMeetingDetail(meeting.id))
                                             }
-
-                                            Spacer()
-                                        }
-                                        .onTapGesture {
-                                            viewStore.send(.pushToMeetingDetail(meeting.id))
-                                        }
                                     }
                                 }
-                                .background(.white)
+                                .padding(.horizontal, 20)
+                                .padding(.top, 23)
                             }
                         }
                     }

--- a/Baggle/Baggle/Features/Tab/Home/HomeView.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeView.swift
@@ -39,9 +39,18 @@ struct HomeView: View {
                             .padding(.top, 23)
                         }
                     }
+                    .refreshable {
+                        viewStore.send(.refreshMeetingList)
+                    }
 
                     // 임시 버튼
                     tempButton(viewStore: viewStore)
+                }
+
+                if viewStore.isRefreshing {
+                    ProgressView()
+                        .padding(.top, 60)
+                        .tint(.white)
                 }
 
                 gradientTop()
@@ -151,27 +160,6 @@ extension HomeView {
         .frame(height: 260)
     }
 
-    func listHeader(viewStore: ViewStore<HomeFeature.State, HomeFeature.Action>) -> some View {
-        SegmentedPickerView(
-            segment: [
-                Segment(
-                    id: .ongoing,
-                    count: viewStore.ongoingList.count,
-                    isSelected: viewStore.meetingStatus == .ongoing,
-                    action: {
-                        viewStore.send(.changeMeetingStatus(.ongoing))
-                    }),
-                Segment(
-                    id: .complete,
-                    count: viewStore.completedList.count,
-                    isSelected: viewStore.meetingStatus == .complete,
-                    action: {
-                        viewStore.send(.changeMeetingStatus(.complete))
-                    })
-            ])
-        .background(.gray)
-    }
-
     // 임시 버튼
     func tempButton(viewStore: ViewStore<HomeFeature.State, HomeFeature.Action>) -> some View {
         VStack {
@@ -191,11 +179,6 @@ extension HomeView {
             .padding()
 
             HStack(spacing: 20) {
-                Button {
-                    viewStore.send(.refreshMeetingList)
-                } label: {
-                    Text("리프레시")
-                }
 
                 Button {
                     viewStore.send(.shareButtonTapped)

--- a/Baggle/Baggle/Features/Tab/Home/HomeView.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeView.swift
@@ -17,30 +17,32 @@ struct HomeView: View {
         WithViewStore(self.store, observe: { $0 }) { viewStore in
             ZStack(alignment: .top) {
 
-//                VStack { // 임시 버튼
-                ScrollView {
-                    header(viewStore: viewStore)
-                    
-                    Section {
-                        VStack(spacing: 12) {
-                            ForEach((viewStore.meetingStatus == .ongoing)
-                                    ? viewStore.ongoingList : viewStore.completedList
-                            ) { meeting in
-                                // cell
-                                MeetingListCell(data: meeting)
-                                    .onTapGesture {
-                                        viewStore.send(.pushToMeetingDetail(meeting.id))
-                                    }
+                VStack { // 임시 버튼용 Vstack
+
+                    ScrollView {
+                        // userInfo + segmentedPicker
+                        header(viewStore: viewStore)
+
+                        Section {
+                            VStack(spacing: 12) {
+                                ForEach((viewStore.meetingStatus == .ongoing)
+                                        ? viewStore.ongoingList : viewStore.completedList
+                                ) { meeting in
+                                    // cell
+                                    MeetingListCell(data: meeting)
+                                        .onTapGesture {
+                                            viewStore.send(.pushToMeetingDetail(meeting.id))
+                                        }
+                                }
                             }
+                            .padding(.horizontal, 20)
+                            .padding(.top, 23)
                         }
-                        .padding(.horizontal, 20)
-                        .padding(.top, 23)
                     }
-                }
 
                     // 임시 버튼
-//                    tempButton(viewStore: viewStore)
-//                }
+                    tempButton(viewStore: viewStore)
+                }
 
                 gradientTop()
             }
@@ -88,9 +90,9 @@ extension HomeView {
                 .font(.system(size: 24))
                 .fontWeight(.bold)
                 .foregroundColor(.white)
-            
+
             Spacer()
-            
+
             Circle()
                 .fill(.gray)
                 .frame(width: 72, height: 72)


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
close #72 

## 내용
<!--
로직 설명  
--> 


**1. CircleProfileView**
- 상황에 맞게 ProfileSize(large, medium, small, extrasmall)를 넣어서 사용할 수 있습니다.
- 크기별로 쓰이는 곳은 주석으로 적어뒀습니다.
- medium 같은 경우 분기처리가 한번 더 들어가야 해서 이후 수정이 필요합니다.
- 임의로 제 깃허브 프로필을 넣어두었습니다..^_^..
```
CircleProfileView(imageUrl: "https://avatars.githubusercontent.com/u/81167570?v=4",
                              size: .large)
```
![스크린샷 2023-08-06 오후 5 07 48](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/25bd2689-3df2-47a5-867f-f117132cfea5)


**2. MeetingListCell**
- 검정색 투명 박스 부분은 '약속 확정', '약속 완료' 스탬프가 들어갈 자리입니다. (자그마한 달 시스템 이미지 임시로 넣어뒀습니다)
```
MeetingListCell(
                data: Meeting(
                    id: 1, name: "유탁님 없는 파티🔔", place: "유탁님 없는 잠실", date: "2023년 10월 23일",
                    time: "15:30", dday: 0, profileImages: ["1", "2", "3", "4", "5", "6"], status: .dday, isConfirmed: true))
```
  <img src= "https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/3f937e91-6683-4458-8124-23f21fd46ffc" width=300>

**3. 전체 스크롤 + 스크롤시 상단 늘어나도록 구현**
  - 늘어나는 모습 확인을 위해 임시로 시스템 이미지 넣어뒀습니다.


### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 
| homeView | + 확인용 버튼 | 
| -------- | -------- | 
| ![ezgif com-video-to-gif (1)](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/00a64dd2-de51-4150-8a04-0802f1797c6e) |![ezgif com-resize (26)](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/b2005e40-1440-42c8-9b26-9a1f71192203) |



## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

처음에 segmentedPicker 부분이 stickyheader가 될 줄 알고 작업하다가 한 번 싸악 수정했습니다.
덜어내는 과정에서 지우지 못한 불필요한 코드가 있을 수 있습니다.. 말씀해주시면 삭제하겠습니당.

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
