### PR TITLE
Feat #82 - Font+ 추가, setBaggleTypo 구현

### DIFF
--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		2B30E33E2A6F9DF000949151 /* UserDefaultKeyList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B30E33D2A6F9DF000949151 /* UserDefaultKeyList.swift */; };
 		2B35E4ED2A70B6DB00915876 /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 2B35E4EC2A70B6DB00915876 /* KakaoSDK */; };
 		2B39F21C2A738BB100E034A3 /* SendInvitation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B39F21B2A738BB100E034A3 /* SendInvitation.swift */; };
+		2B409D7C2A80BE840051A3BC /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B409D7B2A80BE840051A3BC /* Font+.swift */; };
 		2B45F2212A7B634400874783 /* MeetingDeleteType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B45F2202A7B634400874783 /* MeetingDeleteType.swift */; };
 		2B5BE6AF2A779C8E00F25474 /* MeetingDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5BE6AE2A779C8E00F25474 /* MeetingDetail.swift */; };
 		2B5BE6B22A77A40900F25474 /* MeetingDetailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5BE6B12A77A40900F25474 /* MeetingDetailService.swift */; };
@@ -211,6 +212,7 @@
 		2B30E33D2A6F9DF000949151 /* UserDefaultKeyList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultKeyList.swift; sourceTree = "<group>"; };
 		2B30E3452A6FA8E800949151 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		2B39F21B2A738BB100E034A3 /* SendInvitation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendInvitation.swift; sourceTree = "<group>"; };
+		2B409D7B2A80BE840051A3BC /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
 		2B45F2202A7B634400874783 /* MeetingDeleteType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDeleteType.swift; sourceTree = "<group>"; };
 		2B5BE6AE2A779C8E00F25474 /* MeetingDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDetail.swift; sourceTree = "<group>"; };
 		2B5BE6B12A77A40900F25474 /* MeetingDetailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDetailService.swift; sourceTree = "<group>"; };
@@ -414,6 +416,7 @@
 				14F6D9FD2A807E5B00C8C19C /* Color+.swift */,
 				2BD5D5562A6C4EBE0070C196 /* View+Modifier.swift */,
 				2B5CF2672A6EC889004D3033 /* View+.swift */,
+				2B409D7B2A80BE840051A3BC /* Font+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1035,6 +1038,7 @@
 				2B84696D2A6E7AE200D75D32 /* ShadeView.swift in Sources */,
 				2BABCB282A76D08400AFECA3 /* PostObserverAction.swift in Sources */,
 				1432BE6D2A682FCB0098AAA9 /* HomeView.swift in Sources */,
+				2B409D7C2A80BE840051A3BC /* Font+.swift in Sources */,
 				1432BE662A681A600098AAA9 /* LoginFeature.swift in Sources */,
 				141D37712A681569001067E3 /* MainTabFeature.swift in Sources */,
 				2B5BE6AF2A779C8E00F25474 /* MeetingDetail.swift in Sources */,

--- a/Baggle/Baggle/DesignSystem/Extension/Font+.swift
+++ b/Baggle/Baggle/DesignSystem/Extension/Font+.swift
@@ -1,0 +1,25 @@
+//
+//  Font+.swift
+//  Baggle
+//
+//  Created by 양수빈 on 2023/08/07.
+//
+
+import SwiftUI
+
+extension Font {
+    static func baggleFont(size: CGFloat, weight: Font.Weight) -> Font {
+        switch weight {
+        case .bold:
+            return .custom("AppleSDGothicNeo-Bold", size: size)
+        case .semibold:
+            return .custom("AppleSDGothicNeo-SemiBold", size: size)
+        case .medium:
+            return .custom("AppleSDGothicNeo-Medium", size: size)
+        case .regular:
+            return .custom("AppleSDGothicNeo-Regular", size: size)
+        default:
+            return .custom("AppleSDGothicNeo-Regular", size: size)
+        }
+    }
+}

--- a/Baggle/Baggle/DesignSystem/Extension/View+Modifier.swift
+++ b/Baggle/Baggle/DesignSystem/Extension/View+Modifier.swift
@@ -39,6 +39,13 @@ extension View {
     func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
         clipShape(RoundedCorner(radius: radius, corners: corners))
     }
+    
+    /// baggleTypo 설정하는 함수
+    func setBaggleTypo(size: CGFloat, weight: Font.Weight) -> some View {
+        return self
+            .font(.baggleFont(size: size, weight: weight))
+            .lineSpacing(size*0.3)
+    }
 }
 
 struct RoundedCorner: Shape {

--- a/Baggle/Baggle/DesignSystem/Extension/View+Modifier.swift
+++ b/Baggle/Baggle/DesignSystem/Extension/View+Modifier.swift
@@ -40,8 +40,8 @@ extension View {
         clipShape(RoundedCorner(radius: radius, corners: corners))
     }
     
-    /// baggleTypo 설정하는 함수
-    func setBaggleTypo(size: CGFloat, weight: Font.Weight) -> some View {
+    /// baggleFont + lineSpacing 설정하는 함수
+    func baggleTypoLineSpacing(size: CGFloat, weight: Font.Weight) -> some View {
         return self
             .font(.baggleFont(size: size, weight: weight))
             .lineSpacing(size*0.3)


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
close #82 

## 내용
<!--
로직 설명  
--> 
- Font+ 
  - "AppleSDGothicNeo" font 반환하는 함수 baggleFont 생성
- setBaggleTypo
  - baggleFont를 포함해서 lineHeight까지 포함해서 지정해주는 함수입니다.
  - 대부분의 경우 lineHeight가 동일해서 해당 함수를 사용하고, 그 외 일부 lineHeight가 다른 경우 baggleFont와 lineHeight를 별도로 사용하면 될 것 같습니다.

```
/// lineheight까지 포함해서 지정
Text("수빈님네 집들이집들이\n집들이집들이집")
                        .setBaggleTypo(size: 22, weight: .bold)

/// font만 지정
Text("수빈님네 집들이집들이\n집들이집들이집")
                        .font(.baggleFont(size: 22, weight: .bold))
```

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 
실제 디자인에서 지정되어있는 lineHeight는 140%, kerning은 -0.5인데
그대로 적용해서 스크린샷과 비교해보니 요상하게 조금 달랐습니다 그래서 비교한 값 중 가장 비슷한 값으로 지정해줬습니다 (가장 오른쪽)
![스크린샷 2023-08-07 오후 3 23 25](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/9891b17a-6094-4498-b303-26ac08fd2d0c)

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
