### PR TITLE
타이머 데드라인에 따른 분기 처리

### DIFF
--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		141D376F2A681552001067E3 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141D376E2A681552001067E3 /* MainTabView.swift */; };
 		141D37712A681569001067E3 /* MainTabFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141D37702A681569001067E3 /* MainTabFeature.swift */; };
 		1421C0512A7A84A200C20497 /* KakaoLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1421C0502A7A84A200C20497 /* KakaoLoginService.swift */; };
+		142BF96D2A81F50C0042737E /* TimerColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142BF96C2A81F50C0042737E /* TimerColor.swift */; };
 		14315D862A76B1CB008F8064 /* CreateMemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14315D852A76B1CB008F8064 /* CreateMemoView.swift */; };
 		1432BE642A68168A0098AAA9 /* TabType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1432BE632A68168A0098AAA9 /* TabType.swift */; };
 		1432BE662A681A600098AAA9 /* LoginFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1432BE652A681A600098AAA9 /* LoginFeature.swift */; };
@@ -153,6 +154,7 @@
 		141D376E2A681552001067E3 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		141D37702A681569001067E3 /* MainTabFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabFeature.swift; sourceTree = "<group>"; };
 		1421C0502A7A84A200C20497 /* KakaoLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginService.swift; sourceTree = "<group>"; };
+		142BF96C2A81F50C0042737E /* TimerColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerColor.swift; sourceTree = "<group>"; };
 		14315D852A76B1CB008F8064 /* CreateMemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMemoView.swift; sourceTree = "<group>"; };
 		1432BE632A68168A0098AAA9 /* TabType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabType.swift; sourceTree = "<group>"; };
 		1432BE652A681A600098AAA9 /* LoginFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFeature.swift; sourceTree = "<group>"; };
@@ -642,6 +644,7 @@
 			isa = PBXGroup;
 			children = (
 				1493A90F2A7DE4A500A2D7CC /* TimerFeature.swift */,
+				142BF96C2A81F50C0042737E /* TimerColor.swift */,
 				1493A9112A7DE4AB00A2D7CC /* SmallTimerView.swift */,
 				1493A9152A7DE7CB00A2D7CC /* LargeTimerView.swift */,
 			);
@@ -1047,6 +1050,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				14783EE62A7E33B600EF58D5 /* CameraService.swift in Sources */,
+				142BF96D2A81F50C0042737E /* TimerColor.swift in Sources */,
 				143B9CF22A77A39A003CC5E5 /* CreateTitleView.swift in Sources */,
 				14EDE63E2A77A2AD0004F72B /* SignUpSuccessFeature.swift in Sources */,
 				141D376F2A681552001067E3 /* MainTabView.swift in Sources */,

--- a/Baggle/Baggle/Features/Camera/CameraFeature.swift
+++ b/Baggle/Baggle/Features/Camera/CameraFeature.swift
@@ -21,8 +21,9 @@ struct CameraFeature: ReducerProtocol {
 
         var isCompleted: Bool = false
 
-        //Timer
+        // Timer
         var timer = TimerFeature.State()
+        var isTimeOver: Bool = false
     }
 
     enum Action: Equatable {
@@ -45,6 +46,7 @@ struct CameraFeature: ReducerProtocol {
 
         // Timer
         case timer(TimerFeature.Action)
+        case isTimeOverChanged
 
         // Delegate
         case delegate(Delegate)
@@ -139,8 +141,16 @@ struct CameraFeature: ReducerProtocol {
 
                 // MARK: - Timer
 
+            case .timer(.timerOver):
+                state.isTimeOver = true
+                return .none
+
             case .timer:
                 return .none
+
+            case .isTimeOverChanged:
+                state.isTimeOver.toggle()
+                return .run { _ in await self.dismiss() }
 
                 // MARK: - Delegate
 

--- a/Baggle/Baggle/Features/Camera/CameraFeature.swift
+++ b/Baggle/Baggle/Features/Camera/CameraFeature.swift
@@ -46,7 +46,7 @@ struct CameraFeature: ReducerProtocol {
 
         // Timer
         case timer(TimerFeature.Action)
-        case isTimeOverChanged
+        case isTimeOverChanged(Bool)
 
         // Delegate
         case delegate(Delegate)
@@ -142,15 +142,14 @@ struct CameraFeature: ReducerProtocol {
                 // MARK: - Timer
 
             case .timer(.timerOver):
-                state.isTimeOver = true
-                return .none
+                return .run { send in await send(.isTimeOverChanged(true)) }
 
             case .timer:
                 return .none
 
-            case .isTimeOverChanged:
-                state.isTimeOver.toggle()
-                return .run { _ in await self.dismiss() }
+            case let .isTimeOverChanged(isTimeOver):
+                state.isTimeOver = isTimeOver
+                return isTimeOver ? .none : .run { _ in await self.dismiss() }
 
                 // MARK: - Delegate
 

--- a/Baggle/Baggle/Features/Camera/CameraFeature.swift
+++ b/Baggle/Baggle/Features/Camera/CameraFeature.swift
@@ -20,6 +20,9 @@ struct CameraFeature: ReducerProtocol {
         var flipDegree: Double = 0.0
 
         var isCompleted: Bool = false
+
+        //Timer
+        var timer = TimerFeature.State()
     }
 
     enum Action: Equatable {
@@ -40,6 +43,9 @@ struct CameraFeature: ReducerProtocol {
         case reTakeButtonTapped
         case uploadButtonTapped
 
+        // Timer
+        case timer(TimerFeature.Action)
+
         // Delegate
         case delegate(Delegate)
 
@@ -52,6 +58,15 @@ struct CameraFeature: ReducerProtocol {
     @Dependency(\.cameraService) var cameraService
 
     var body: some ReducerProtocolOf<Self> {
+
+        // MARK: - Scope
+
+        Scope(state: \.timer, action: /Action.timer) {
+            TimerFeature()
+        }
+
+        // MARK: - Reduce
+
         Reduce { state, action in
 
             switch action {
@@ -122,7 +137,12 @@ struct CameraFeature: ReducerProtocol {
                 // 이미지 업로드
                 return .run { _ in await self.dismiss() }
 
-            // MARK: - Delegate
+                // MARK: - Timer
+
+            case .timer:
+                return .none
+
+                // MARK: - Delegate
 
             case .delegate:
                 return .none

--- a/Baggle/Baggle/Features/Camera/CameraView.swift
+++ b/Baggle/Baggle/Features/Camera/CameraView.swift
@@ -58,13 +58,13 @@ extension CameraView {
     // MARK: - Timer
 
     private func timer(viewStore: CameraFeatureViewStore) -> some View {
-        Text("03:39")
-            .padding(.vertical, 10)
-            .padding(.horizontal, 24)
-            .foregroundColor(Color.black)
-            .background(Color.white)
-            .cornerRadius(12)
-            .padding(.top, 12)
+        LargeTimerView(
+            store: self.store.scope(
+                state: \.timer,
+                action: CameraFeature.Action.timer
+            )
+        )
+        .padding(.top, 12)
     }
 
     // MARK: - ViewFinder
@@ -126,7 +126,7 @@ extension CameraView {
         }
         .frame(height: 62)
         .padding(.top, 42)
-        .padding(.bottom, 90)
+        .padding(.bottom, 64)
     }
 
     private func cameraButtons(viewStore: CameraFeatureViewStore) -> some View {

--- a/Baggle/Baggle/Features/Camera/CameraView.swift
+++ b/Baggle/Baggle/Features/Camera/CameraView.swift
@@ -37,27 +37,7 @@ struct CameraView: View {
                 .background(Color.black)
 
                 if viewStore.isTimeOver {
-
-                    ZStack {
-                        ShadeView(
-                            isPresented: viewStore.binding(
-                                get: \.isTimeOver,
-                                send: CameraFeature.Action.isTimeOverChanged
-                            )
-                        )
-
-                        Text("시간이 초과되었습니다.")
-                            .font(.system(size: 22))
-                            .foregroundColor(.white)
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, 16)
-                            .background(.black)
-                            .cornerRadius(12)
-                    }
-                    .animation(.easeInOut(duration: 0.2), value: viewStore.isTimeOver)
-                    .onTapGesture {
-                        viewStore.send(.isTimeOverChanged)
-                    }
+                    timeOverView(viewStore: viewStore)
                 }
             }
             .onAppear {
@@ -239,5 +219,30 @@ extension CameraView {
         }
         .font(.system(size: 18).bold())
         .padding(.horizontal, 20)
+    }
+
+    // MARK: - 시간 초과
+
+    private func timeOverView(viewStore: CameraFeatureViewStore) -> some View {
+        ZStack {
+            ShadeView(
+                isPresented: viewStore.binding(
+                    get: \.isTimeOver,
+                    send: { CameraFeature.Action.isTimeOverChanged($0) }
+                )
+            )
+
+            Text("시간이 초과되었습니다.")
+                .font(.system(size: 22))
+                .foregroundColor(.white)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 16)
+                .background(.black)
+                .cornerRadius(12)
+        }
+        .animation(.easeInOut(duration: 0.2), value: viewStore.isTimeOver)
+        .onTapGesture {
+            viewStore.send(.isTimeOverChanged(false))
+        }
     }
 }

--- a/Baggle/Baggle/Features/Camera/CameraView.swift
+++ b/Baggle/Baggle/Features/Camera/CameraView.swift
@@ -22,21 +22,46 @@ struct CameraView: View {
 
         WithViewStore(self.store, observe: { $0 }) { viewStore in
 
-            VStack(spacing: 0) {
-                Spacer()
+            ZStack {
+                VStack(spacing: 0) {
+                    Spacer()
 
-                description(viewStore: viewStore)
+                    description(viewStore: viewStore)
 
-                timer(viewStore: viewStore)
+                    timer(viewStore: viewStore)
 
-                viewFinderView(viewStore: viewStore)
+                    viewFinderView(viewStore: viewStore)
 
-                buttonsView(viewStore: viewStore)
+                    buttonsView(viewStore: viewStore)
+                }
+                .background(Color.black)
+
+                if viewStore.isTimeOver {
+
+                    ZStack {
+                        ShadeView(
+                            isPresented: viewStore.binding(
+                                get: \.isTimeOver,
+                                send: CameraFeature.Action.isTimeOverChanged
+                            )
+                        )
+
+                        Text("시간이 초과되었습니다.")
+                            .font(.system(size: 22))
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, 16)
+                            .background(.black)
+                            .cornerRadius(12)
+                    }
+                    .animation(.easeInOut(duration: 0.2), value: viewStore.isTimeOver)
+                    .onTapGesture {
+                        viewStore.send(.isTimeOverChanged)
+                    }
+                }
             }
-            .background(Color.black)
             .onAppear {
                 viewStore.send(.onAppear)
-                print(viewStore)
             }
         }
     }

--- a/Baggle/Baggle/Features/Common/Timer/LargeTimerView.swift
+++ b/Baggle/Baggle/Features/Common/Timer/LargeTimerView.swift
@@ -12,28 +12,36 @@ import ComposableArchitecture
 struct LargeTimerView: View {
 
     let store: StoreOf<TimerFeature>
-    let numberWidth: CGFloat = 17
+    let numberWidth: CGFloat = 18
+    let deadline: Int = 10
 
     var body: some View {
 
         WithViewStore(self.store, observe: { $0 }) { viewStore in
+
             HStack(alignment: .bottom, spacing: 0) {
-                Text("\(viewStore.timerCount.minutes.tenDigit)")
-                    .frame(width: numberWidth)
-                Text("\(viewStore.timerCount.minutes.oneDigit)")
-                    .frame(width: numberWidth)
-                Text(":")
-                Text("\(viewStore.timerCount.seconds.tenDigit)")
-                    .frame(width: numberWidth)
-                Text("\(viewStore.timerCount.seconds.oneDigit)")
-                    .frame(width: numberWidth)
+
+                if viewStore.isTimerOver {
+                    Text("TIMEOUT")
+                } else {
+                    Text("\(viewStore.timerCount.minutes.tenDigit)")
+                        .frame(width: numberWidth)
+                    Text("\(viewStore.timerCount.minutes.oneDigit)")
+                        .frame(width: numberWidth)
+                    Text(":")
+                    Text("\(viewStore.timerCount.seconds.tenDigit)")
+                        .frame(width: numberWidth)
+                    Text("\(viewStore.timerCount.seconds.oneDigit)")
+                        .frame(width: numberWidth)
+                }
             }
             .font(.system(size: 28).bold())
             .padding(.vertical, 20)
             .padding(.horizontal, 24)
             .foregroundColor(Color.black)
-            .background(Color.white)
+            .background(viewStore.timerCount <= 10 ? Color.red : Color.white)
             .cornerRadius(12)
+            .animation(.easeInOut(duration: 0.3), value: viewStore.isTimerOver)
             .onAppear {
                 viewStore.send(.onAppear)
             }

--- a/Baggle/Baggle/Features/Common/Timer/LargeTimerView.swift
+++ b/Baggle/Baggle/Features/Common/Timer/LargeTimerView.swift
@@ -42,7 +42,7 @@ struct LargeTimerView: View {
                 }
             }
             .font(.system(size: 28).bold())
-            .padding(.vertical, 20)
+            .padding(.vertical, 12)
             .padding(.horizontal, 24)
             .foregroundColor(color.foregroundColor)
             .background(viewStore.timerCount <= 10 ? Color.red : color.backgroundColor)

--- a/Baggle/Baggle/Features/Common/Timer/LargeTimerView.swift
+++ b/Baggle/Baggle/Features/Common/Timer/LargeTimerView.swift
@@ -12,8 +12,14 @@ import ComposableArchitecture
 struct LargeTimerView: View {
 
     let store: StoreOf<TimerFeature>
+    let color: TimerColor
     let numberWidth: CGFloat = 18
     let deadline: Int = 10
+
+    init(store: StoreOf<TimerFeature>, color: TimerColor = .white) {
+        self.store = store
+        self.color = color
+    }
 
     var body: some View {
 
@@ -38,8 +44,8 @@ struct LargeTimerView: View {
             .font(.system(size: 28).bold())
             .padding(.vertical, 20)
             .padding(.horizontal, 24)
-            .foregroundColor(Color.black)
-            .background(viewStore.timerCount <= 10 ? Color.red : Color.white)
+            .foregroundColor(color.foregroundColor)
+            .background(viewStore.timerCount <= 10 ? Color.red : color.backgroundColor)
             .cornerRadius(12)
             .animation(.easeInOut(duration: 0.3), value: viewStore.isTimerOver)
             .onAppear {

--- a/Baggle/Baggle/Features/Common/Timer/TimerColor.swift
+++ b/Baggle/Baggle/Features/Common/Timer/TimerColor.swift
@@ -1,0 +1,30 @@
+//
+//  TimerStatus.swift
+//  Baggle
+//
+//  Created by youtak on 2023/08/08.
+//
+
+import SwiftUI
+
+enum TimerColor {
+    case black
+    case white
+}
+
+extension TimerColor {
+
+    var backgroundColor: Color {
+        switch self {
+        case .black: return .black
+        case .white: return .white
+        }
+    }
+
+    var foregroundColor: Color {
+        switch self {
+        case .black: return .white
+        case .white: return .black
+        }
+    }
+}

--- a/Baggle/Baggle/Features/Common/Timer/TimerFeature.swift
+++ b/Baggle/Baggle/Features/Common/Timer/TimerFeature.swift
@@ -12,7 +12,7 @@ import ComposableArchitecture
 struct TimerFeature: ReducerProtocol {
 
     struct State: Equatable {
-        var targetDate: Date = Date().later(seconds: 12)
+        var targetDate: Date = Date().later(seconds: 3)
 
         var timerCount: Int = 0
         var isTimerOver: Bool = false

--- a/Baggle/Baggle/Features/Common/Timer/TimerFeature.swift
+++ b/Baggle/Baggle/Features/Common/Timer/TimerFeature.swift
@@ -12,7 +12,7 @@ import ComposableArchitecture
 struct TimerFeature: ReducerProtocol {
 
     struct State: Equatable {
-        var targetDate: Date = Date().later(seconds: 5)
+        var targetDate: Date = Date().later(seconds: 12)
 
         var timerCount: Int = 0
         var isTimerOver: Bool = false

--- a/Baggle/Baggle/Sources/BaggleApp.swift
+++ b/Baggle/Baggle/Sources/BaggleApp.swift
@@ -26,7 +26,7 @@ struct BaggleApp: App {
             AppView(
                 store: Store(
                     initialState: AppFeature.State(
-                        isLoggedIn: false,
+                        isLoggedIn: true,
                         loginFeature: LoginFeature.State(),
                         mainTabFeature: MainTabFeature.State(
                             selectedTab: .home,


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #95 

## 내용
<!--
로직 설명  
--> 
- 타이머 데드라인을 10초로 설정하고 그에 따라 디자인 분기처리를 해주었습니다. 남은 시간이 0초가 되면 "TIMEOUT" 텍스트로 변경됩니다.
- TimeOut이 되면 시간 초과 안내가 나옵니다. Tap 시 카메라 View를 dismiss 해주었습니다.
- 흰색, 검정색 타이머 분기 처리를 위해 `Large Timer View`에 `Timer Color`를 추가해주었습니다. 흰색은 카메라, 검정색은 긴급버튼 View에서 사용됩니다.
- 카메라 View와 연결했습니다.

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

10초로 진입했을 때

![Simulator Screen Recording - iPhone 13 mini - 2023-08-08 at 14 07 53](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/3aff2f75-4b5f-4529-b4ab-92b48e03a55f)


시간 초과했을 때

![Simulator Screen Recording - iPhone 13 mini - 2023-08-08 at 14 07 27](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/f87466dc-fccf-4dd8-939d-915510a4514a)


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- 처음 네트워크로 받아올 때 남은 시간을 count를 변수로 가질까 했는데 타이머 시간이 계속 흘러서 실제 Model이랑 어떻게 연결하지 고민입니다.
- 네트워크 요청 중인데 TimeOut 됐을 때 분기처리가 필요합니다.

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
