### PR TITLE
Spacer Touch를 위한 Modifier 추가

### DIFF
--- a/Baggle/Baggle/DesignSystem/Extension/View+Modifier.swift
+++ b/Baggle/Baggle/DesignSystem/Extension/View+Modifier.swift
@@ -46,6 +46,12 @@ extension View {
             .font(.baggleFont(size: size, weight: weight))
             .lineSpacing(size*0.3)
     }
+
+    // MARK: Spacer() 영역 터치
+
+    func touchSpacer() -> some View {
+        modifier(ContentShapeModifier())
+    }
 }
 
 struct RoundedCorner: Shape {
@@ -60,5 +66,14 @@ struct RoundedCorner: Shape {
                                     width: radius,
                                     height: radius))
         return Path(path.cgPath)
+    }
+}
+
+// MARK: - Spacer() 영역 터치
+
+struct ContentShapeModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .contentShape(Rectangle())
     }
 }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Date/CreateDateView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Date/CreateDateView.swift
@@ -46,7 +46,7 @@ struct CreateDateView: View {
                                 RoundedRectangle(cornerRadius: 10)
                                     .stroke(viewStore.dateButtonStatus.borderColor, lineWidth: 1)
                             )
-                            .contentShape(Rectangle())
+                            .touchSpacer()
                             .onTapGesture {
                                 viewStore.send(.selectDateButtonTapped)
                             }
@@ -64,7 +64,7 @@ struct CreateDateView: View {
                                 RoundedRectangle(cornerRadius: 10)
                                     .stroke(viewStore.timeButtonStatus.borderColor, lineWidth: 1)
                             )
-                            .contentShape(Rectangle())
+                            .touchSpacer()
                             .onTapGesture {
                                 viewStore.send(.selectTimeButtonTapped)
                             }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoView.swift
@@ -37,7 +37,7 @@ struct CreateMemoView: View {
                 }
                 .buttonStyle(BagglePrimaryStyle())
             }
-            .contentShape(Rectangle())
+            .touchSpacer()
             .onTapGesture {
                 hideKeyboard()
             }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Place/CreatePlaceView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Place/CreatePlaceView.swift
@@ -44,7 +44,7 @@ struct CreatePlaceView: View {
                 .disabled(viewStore.state.nextButtonDisabled)
             }
             .padding()
-            .contentShape(Rectangle())
+            .touchSpacer()
             .onTapGesture {
                 hideKeyboard()
             }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleView.swift
@@ -55,7 +55,7 @@ struct CreateTitleView: View {
                         }
                     }
                 }
-                .contentShape(Rectangle())
+                .touchSpacer()
                 .onTapGesture {
                     hideKeyboard()
                 }

--- a/Baggle/Baggle/Features/Tab/Home/Common/MeetingListCell.swift
+++ b/Baggle/Baggle/Features/Tab/Home/Common/MeetingListCell.swift
@@ -78,6 +78,7 @@ struct MeetingListCell: View {
                     .padding(.trailing, 16)
             }
         }
+        .touchSpacer()
         .overlay {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(data.status.fgColor, lineWidth: 1)


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #105 

## 내용
<!--
로직 설명  
--> 
- Spacer() 영역은 background가 없으면 기본적으로 터치가 안되서 `.contentShape(Rectangle())`를 추가해주어야 터치가 됩니다. 가독성이 별로인 것 같아 `touchSpacer()` 메소드를 만들었습니다.

사용법

```swift
VStack {
  // 생략..

  Spacer()

  // 생략...
}
.touchSpacer()
```

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

![스크린샷 2023-08-08 오후 7 58 30](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/5102d878-f66a-45e9-9911-bf69d6913b3f)
기존에 파란색 원 영역이 누르면 터치 인식이 안됐는데 메소드 추가해서 인식되게 했습니다.

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
