### PR TITLE
Feature - 이미지 상세 뷰

### DIFF
--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		2B7EC32B2A8228F300D78141 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 2B7EC32A2A8228F300D78141 /* Kingfisher */; };
 		2B7EC32D2A822E5B00D78141 /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7EC32C2A822E5B00D78141 /* UINavigationController+.swift */; };
 		2B7EC32F2A8251DC00D78141 /* HomeStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7EC32E2A8251DC00D78141 /* HomeStatus.swift */; };
+		2B7EC3322A826F4D00D78141 /* ImageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7EC3312A826F4D00D78141 /* ImageDetailView.swift */; };
 		2B84696A2A6E7AE200D75D32 /* BaggleAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B84695F2A6E7AE200D75D32 /* BaggleAlert.swift */; };
 		2B84696B2A6E7AE200D75D32 /* BaggleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8469612A6E7AE200D75D32 /* BaggleTextField.swift */; };
 		2B84696C2A6E7AE200D75D32 /* BaggleTextFieldType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8469622A6E7AE200D75D32 /* BaggleTextFieldType.swift */; };
@@ -241,6 +242,7 @@
 		2B604DD92A7F60E7000E2DE2 /* CircleProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleProfileView.swift; sourceTree = "<group>"; };
 		2B7EC32C2A822E5B00D78141 /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
 		2B7EC32E2A8251DC00D78141 /* HomeStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeStatus.swift; sourceTree = "<group>"; };
+		2B7EC3312A826F4D00D78141 /* ImageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDetailView.swift; sourceTree = "<group>"; };
 		2B84695F2A6E7AE200D75D32 /* BaggleAlert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaggleAlert.swift; sourceTree = "<group>"; };
 		2B8469612A6E7AE200D75D32 /* BaggleTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaggleTextField.swift; sourceTree = "<group>"; };
 		2B8469622A6E7AE200D75D32 /* BaggleTextFieldType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaggleTextFieldType.swift; sourceTree = "<group>"; };
@@ -837,6 +839,14 @@
 			path = MeetingDetail;
 			sourceTree = "<group>";
 		};
+		2B7EC3302A826ECF00D78141 /* ImageDetail */ = {
+			isa = PBXGroup;
+			children = (
+				2B7EC3312A826F4D00D78141 /* ImageDetailView.swift */,
+			);
+			path = ImageDetail;
+			sourceTree = "<group>";
+		};
 		2B84695D2A6E7AE200D75D32 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -937,6 +947,7 @@
 			isa = PBXGroup;
 			children = (
 				2B9F27152A813ABE009ED284 /* Common */,
+				2B7EC3302A826ECF00D78141 /* ImageDetail */,
 				14E577A82A80970C00119FB3 /* Emergency */,
 				2B2BA5272A7AB45300A90AE7 /* SelectHost */,
 				2BABCB2A2A76D1AF00AFECA3 /* MeetingDetailFeature.swift */,
@@ -1176,6 +1187,7 @@
 				2BA760B72A81DD4A0089878D /* MeetingStatus.swift in Sources */,
 				2BE5299E2A7D697800A53779 /* MeetingListCell.swift in Sources */,
 				14B7A0412A753D4800B8E202 /* SignUpService.swift in Sources */,
+				2B7EC3322A826F4D00D78141 /* ImageDetailView.swift in Sources */,
 				1461B6022A7BA8C500A15706 /* RoundedTriangle.swift in Sources */,
 				14E5064E2A6B88F7008D5778 /* SignUpView.swift in Sources */,
 				14EBE4BE2A68130F007537C8 /* LoginView.swift in Sources */,

--- a/Baggle/Baggle/Core/Services/MeetingDetail/MeetingDetailService.swift
+++ b/Baggle/Baggle/Core/Services/MeetingDetail/MeetingDetailService.swift
@@ -45,7 +45,8 @@ struct MockUpMeetingDetailService {
                    isMeetingAuthority: true,
                    isButtonAuthority: true,
                    certified: true,
-                   certImage: ""),
+                   // swiftlint:disable:next line_length
+                   certImage: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/Golde33443.jpg/280px-Golde33443.jpg"),
             Member(id: 2,
                    name: "안녕222",
                    profileURL: "",
@@ -59,7 +60,8 @@ struct MockUpMeetingDetailService {
                    isMeetingAuthority: true,
                    isButtonAuthority: false,
                    certified: true,
-                   certImage: ""),
+                   // swiftlint:disable:next line_length
+                   certImage: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/Pupplies_loving.jpg/1920px-Pupplies_loving.jpg"),
             Member(id: 4,
                    name: "감자탕",
                    profileURL: "",
@@ -80,7 +82,9 @@ struct MockUpMeetingDetailService {
             emergencyButtonActive: false,
             emergencyButtonActiveTime: nil,
             feeds: [
+                // swiftlint:disable:next line_length
                 Feed(id: 0, userId: 1, username: "수빈", userImageURL: "https://avatars.githubusercontent.com/u/81167570?v=4", feedImageURL: ""),
+                // swiftlint:disable:next line_length
                 Feed(id: 1, userId: 2, username: "유탁", userImageURL: "", feedImageURL: "https://avatars.githubusercontent.com/u/81167570?v=4")
             ]
         )

--- a/Baggle/Baggle/DesignSystem/View/Button/BaggleButtonStyle.swift
+++ b/Baggle/Baggle/DesignSystem/View/Button/BaggleButtonStyle.swift
@@ -117,3 +117,40 @@ struct BaggleSecondaryStyle: ButtonStyle {
             .cornerRadius(54/2)
     }
 }
+
+struct BaggleTertiaryStyle: ButtonStyle {
+    private let foregroundColor: Color = .gray14
+    private let backgroundColor: Color = .white
+
+    @Environment(\.isEnabled) private var isEnabled
+
+    private func foregroundColor(_ isPressed: Bool) -> Color {
+        if !isEnabled {
+            return foregroundColor
+        } else if isPressed {
+            return foregroundColor.opacity(0.5)
+        } else {
+            return foregroundColor
+        }
+    }
+
+    private func backgroundColor(_ isPressed: Bool) -> Color {
+        if !isEnabled {
+            return Color.gray // 디자인 확정 시 수정
+        } else if isPressed {
+            return backgroundColor.opacity(0.5)
+        } else {
+            return backgroundColor
+        }
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 16, weight: .semibold))
+            .frame(height: 54)
+            .padding(.horizontal, 32)
+            .foregroundColor(foregroundColor(configuration.isPressed))
+            .background(backgroundColor(configuration.isPressed))
+            .cornerRadius(27)
+    }
+}

--- a/Baggle/Baggle/Features/MeetingDetail/ImageDetail/ImageDetailView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/ImageDetail/ImageDetailView.swift
@@ -11,38 +11,35 @@ import ComposableArchitecture
 import Kingfisher
 
 struct ImageDetailView: View {
-    @State var isPresented: Bool = false
+
+    @Binding var isPresented: Bool
+    let imageURL: String
+    let closeButtonAction: () -> Void
 
     var body: some View {
         ZStack {
             ShadeView(isPresented: $isPresented)
 
-            VStack(spacing: 16) {
-                KFImage(URL(string: ""))
-                    .placeholder { _ in
-                        Color.grayF5
-                    }
-                    .resizable()
-                    .aspectRatio(1.0, contentMode: .fill)
-                    .cornerRadius(12)
-                    .clipped()
-                    .frame(width: screenSize.width - 40, height: screenSize.width - 40)
-                    .padding(.top, 70) // 이미지 기준 가운데 정렬 맞추기 위해 버튼 크기만큼 상단 패딩 추가
+            if isPresented {
+                VStack(spacing: 16) {
+                    KFImage(URL(string: imageURL))
+                        .placeholder { _ in
+                            Color.grayF5
+                        }
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: screenSize.width - 40, height: screenSize.width - 40)
+                        .cornerRadius(12)
+                        .padding(.top, 70) // 이미지 기준 가운데 정렬 맞추기 위해 버튼 크기만큼 상단 패딩 추가
 
-                Button("닫기") {
-                    print("닫기")
+                    Button("닫기") {
+                        closeButtonAction()
+                    }
+                    .buttonStyle(BaggleTertiaryStyle())
                 }
-                .buttonStyle(BaggleTertiaryStyle())
             }
         }
-        .onAppear { isPresented = true }
-        .onDisappear { isPresented = false }
-    }
-}
-
-struct ImageDetailView_Previews: PreviewProvider {
-    static var previews: some View {
-        ImageDetailView()
-            .previewLayout(.sizeThatFits)
+//        .onAppear { isPresented = true }
+//        .onDisappear { isPresented = false }
     }
 }

--- a/Baggle/Baggle/Features/MeetingDetail/ImageDetail/ImageDetailView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/ImageDetail/ImageDetailView.swift
@@ -13,6 +13,8 @@ import Kingfisher
 struct ImageDetailView: View {
 
     @Binding var isPresented: Bool
+    @State var isAnimating: Bool = false
+
     let imageURL: String
     let closeButtonAction: () -> Void
 
@@ -20,26 +22,26 @@ struct ImageDetailView: View {
         ZStack {
             ShadeView(isPresented: $isPresented)
 
-            if isPresented {
-                VStack(spacing: 16) {
-                    KFImage(URL(string: imageURL))
-                        .placeholder { _ in
-                            Color.grayF5
-                        }
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: screenSize.width - 40, height: screenSize.width - 40)
-                        .cornerRadius(12)
-                        .padding(.top, 70) // 이미지 기준 가운데 정렬 맞추기 위해 버튼 크기만큼 상단 패딩 추가
-
-                    Button("닫기") {
-                        closeButtonAction()
+            VStack(spacing: 16) {
+                KFImage(URL(string: imageURL))
+                    .placeholder { _ in
+                        Color.grayF5
                     }
-                    .buttonStyle(BaggleTertiaryStyle())
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: screenSize.width - 40, height: screenSize.width - 40)
+                    .cornerRadius(12)
+                    .padding(.top, 70) // 이미지 기준 가운데 정렬 맞추기 위해 버튼 크기만큼 상단 패딩 추가
+
+                Button("닫기") {
+                    closeButtonAction()
                 }
+                .buttonStyle(BaggleTertiaryStyle())
             }
+            .opacity(isAnimating ? 1 : 0)
+            .animation(.easeInOut(duration: 0.2), value: isAnimating)
         }
-//        .onAppear { isPresented = true }
-//        .onDisappear { isPresented = false }
+        .onAppear { isAnimating = true }
+        .onDisappear { isAnimating = false }
     }
 }

--- a/Baggle/Baggle/Features/MeetingDetail/ImageDetail/ImageDetailView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/ImageDetail/ImageDetailView.swift
@@ -31,7 +31,7 @@ struct ImageDetailView: View {
                     .scaledToFill()
                     .frame(width: screenSize.width - 40, height: screenSize.width - 40)
                     .cornerRadius(12)
-                    .padding(.top, 70) // 이미지 기준 가운데 정렬 맞추기 위해 버튼 크기만큼 상단 패딩 추가
+                    .padding(.top, 70)
 
                 Button("닫기") {
                     closeButtonAction()

--- a/Baggle/Baggle/Features/MeetingDetail/ImageDetail/ImageDetailView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/ImageDetail/ImageDetailView.swift
@@ -1,0 +1,48 @@
+//
+//  ImageDetailView.swift
+//  Baggle
+//
+//  Created by 양수빈 on 2023/08/08.
+//
+
+import SwiftUI
+
+import ComposableArchitecture
+import Kingfisher
+
+struct ImageDetailView: View {
+    @State var isPresented: Bool = false
+
+    var body: some View {
+        ZStack {
+            ShadeView(isPresented: $isPresented)
+
+            VStack(spacing: 16) {
+                KFImage(URL(string: ""))
+                    .placeholder { _ in
+                        Color.grayF5
+                    }
+                    .resizable()
+                    .aspectRatio(1.0, contentMode: .fill)
+                    .cornerRadius(12)
+                    .clipped()
+                    .frame(width: screenSize.width - 40, height: screenSize.width - 40)
+                    .padding(.top, 70) // 이미지 기준 가운데 정렬 맞추기 위해 버튼 크기만큼 상단 패딩 추가
+
+                Button("닫기") {
+                    print("닫기")
+                }
+                .buttonStyle(BaggleTertiaryStyle())
+            }
+        }
+        .onAppear { isPresented = true }
+        .onDisappear { isPresented = false }
+    }
+}
+
+struct ImageDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        ImageDetailView()
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -34,6 +34,10 @@ struct MeetingDetailFeature: ReducerProtocol {
         var alertDescription: String?
         var alertRightButtonTitle: String = ""
 
+        // Feed
+        var isImageTapped: Bool = false
+        var tappedImageUrl: String?
+
         // Child
         var timerState = TimerFeature.State(targetDate: Date().later(minutes: 1).later(seconds: 10))
 
@@ -64,6 +68,9 @@ struct MeetingDetailFeature: ReducerProtocol {
         case emergencyButtonTapped
         case inviteButtonTapped
         case eventButtonTapped
+
+        // feed
+        case imageTapped(String?)
 
         // error
         case invitationFailed
@@ -197,6 +204,11 @@ struct MeetingDetailFeature: ReducerProtocol {
 
             case .invitationFailed:
                 print("초대 실패 alert")
+                return .none
+
+            case .imageTapped(let imageUrl):
+                state.isImageTapped.toggle()
+                state.tappedImageUrl = imageUrl
                 return .none
 
                 // Child - Delete

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
@@ -75,29 +75,23 @@ struct MeetingDetailView: View {
                 if viewStore.isAlertPresented {
                     baggleAlert(viewStore: viewStore)
                 }
+
+                // 이미지 상세
+                if viewStore.isImageTapped,
+                   let image = viewStore.tappedImageUrl {
+                    imageDetailView(image: image, viewStore: viewStore)
+                }
             }
             .toolbar(.hidden, for: .navigationBar)
             // 임시 액션시트
             .confirmationDialog("임시 액션시트", isPresented: $isActionSheetShow, actions: {
-                Button("방 폭파하기") {
-                    viewStore.send(.deleteButtonTapped)
-                }
+                Button("방 폭파하기") { viewStore.send(.deleteButtonTapped) }
 
-                Button("방장 넘기기") {
-                    viewStore.send(.leaveButtonTapped)
-                }
+                Button("방장 넘기기") { viewStore.send(.leaveButtonTapped) }
 
-                Button {
-                    viewStore.send(.cameraButtonTapped)
-                } label: {
-                    Text("카메라")
-                }
+                Button("카메라") { viewStore.send(.cameraButtonTapped) }
 
-                Button {
-                    viewStore.send(.emergencyButtonTapped)
-                } label: {
-                    Text("긴급 버튼")
-                }
+                Button("긴급 버튼") { viewStore.send(.emergencyButtonTapped) }
             })
             .sheet(
                 store: self.store.scope(
@@ -238,6 +232,11 @@ extension MeetingDetailView {
                                 size: .medium,
                                 hasStroke: member.certified
                             )
+                            .onTapGesture {
+                                if member.certified {
+                                    viewStore.send(.imageTapped(member.certImage))
+                                }
+                            }
 
                             HStack(spacing: -10) {
                                 if member.isMeetingAuthority {
@@ -315,6 +314,17 @@ extension MeetingDetailView {
             rightButtonTitle: viewStore.alertRightButtonTitle) {
                 viewStore.send(.deleteMeeting)
             }
+    }
+
+    func imageDetailView(image: String, viewStore: Viewstore) -> some View {
+        ImageDetailView(
+            isPresented: Binding(
+                get: { viewStore.isImageTapped },
+                set: { _ in viewStore.send(.imageTapped(viewStore.tappedImageUrl)) }),
+            imageURL: image
+        ) {
+            viewStore.send(.imageTapped(nil))
+        }
     }
 }
 


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 

close #96 

## 내용
<!--
로직 설명  
--> 
1. ButtonStyle -> BaggleTertiaryStyle 추가
<img src="https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/bf80eea2-ea10-4ea3-82c4-f0facc909b0b" width=200>

2. ImageDetailView 추가, 모임 상세 프로필 탭 연결

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 
![ezgif com-video-to-gif (2)](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/ea3feac8-bef8-4a77-a607-f0027a609681)


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- ButtonStyle 이름을 기능 위주로 바꿀 필요가 있을까요 ? 
  - 기존 버튼 스타일을 primary, secondary로 해서 이번에는 tertiary로 했는데, 스타일이름 자체에 어떤 용도의 버튼인지가 명확하게 보이는게 더 나을 것 같기도 해서 ..
- 임시버튼들 코드가 길어서 조금 정리했습니다

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
