### PR TITLE
모임 상세 화면 - 버튼 로직 확인

### DIFF
--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		140E88202A64C3A8005119F8 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 140E881F2A64C3A8005119F8 /* ComposableArchitecture */; };
 		140E88232A64C3C2005119F8 /* CombineMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 140E88222A64C3C2005119F8 /* CombineMoya */; };
 		140E88252A64C3C2005119F8 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 140E88242A64C3C2005119F8 /* Moya */; };
+		1410AD242A84BEA8008793FB /* Feed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1410AD232A84BEA8008793FB /* Feed.swift */; };
+		1410AD262A84BEB6008793FB /* Memeber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1410AD252A84BEB6008793FB /* Memeber.swift */; };
 		14134D542A64C944004A6AC4 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 14134D522A64C944004A6AC4 /* .swiftlint.yml */; };
 		14134D552A64C944004A6AC4 /* .swiftlint.auto.yml in Resources */ = {isa = PBXBuildFile; fileRef = 14134D532A64C944004A6AC4 /* .swiftlint.auto.yml */; };
 		1413925E2A78E66600249C8A /* CircleNumberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1413925D2A78E66600249C8A /* CircleNumberView.swift */; };
@@ -67,9 +69,9 @@
 		149C0F482A77850A00B95A36 /* CreateSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149C0F472A77850A00B95A36 /* CreateSuccessView.swift */; };
 		14B7A0412A753D4800B8E202 /* SignUpService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B7A0402A753D4800B8E202 /* SignUpService.swift */; };
 		14B7A0452A75409E00B8E202 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B7A0442A75409E00B8E202 /* NetworkError.swift */; };
+		14CF68E92A846EB700E457DF /* TestDateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CF68E82A846EB700E457DF /* TestDateService.swift */; };
 		14CF68EC2A847BEF00E457DF /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CF68EB2A847BEF00E457DF /* User.swift */; };
 		14CF68EE2A847C5C00E457DF /* LoginPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CF68ED2A847C5C00E457DF /* LoginPlatform.swift */; };
-		14CF68E92A846EB700E457DF /* TestDateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CF68E82A846EB700E457DF /* TestDateService.swift */; };
 		14E0836A2A83690D0001CB21 /* EntityContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E083692A83690D0001CB21 /* EntityContainer.swift */; };
 		14E0836D2A836A8C0001CB21 /* MeetingDetailEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E0836C2A836A8C0001CB21 /* MeetingDetailEntity.swift */; };
 		14E0836F2A836C1D0001CB21 /* MeetingDetailMemberEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E0836E2A836C1D0001CB21 /* MeetingDetailMemberEntity.swift */; };
@@ -164,6 +166,8 @@
 		140E88122A64B626005119F8 /* AppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
 		140E88142A64B627005119F8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		140E88172A64B627005119F8 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		1410AD232A84BEA8008793FB /* Feed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feed.swift; sourceTree = "<group>"; };
+		1410AD252A84BEB6008793FB /* Memeber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Memeber.swift; sourceTree = "<group>"; };
 		14134D522A64C944004A6AC4 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		14134D532A64C944004A6AC4 /* .swiftlint.auto.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.auto.yml; sourceTree = "<group>"; };
 		1413925D2A78E66600249C8A /* CircleNumberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleNumberView.swift; sourceTree = "<group>"; };
@@ -367,6 +371,16 @@
 				140E88172A64B627005119F8 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		1410AD222A84BE9B008793FB /* MeetingDetail */ = {
+			isa = PBXGroup;
+			children = (
+				2B5BE6AE2A779C8E00F25474 /* MeetingDetail.swift */,
+				1410AD232A84BEA8008793FB /* Feed.swift */,
+				1410AD252A84BEB6008793FB /* Memeber.swift */,
+			);
+			path = MeetingDetail;
 			sourceTree = "<group>";
 		};
 		14134D382A64C4CC004A6AC4 /* Resources */ = {
@@ -739,7 +753,7 @@
 			children = (
 				2BA760B62A81DD4A0089878D /* MeetingStatus.swift */,
 				2BF2681F2A77828100F32ADF /* Meeting.swift */,
-				2B5BE6AE2A779C8E00F25474 /* MeetingDetail.swift */,
+				1410AD222A84BE9B008793FB /* MeetingDetail */,
 			);
 			path = Meeting;
 			sourceTree = "<group>";
@@ -1231,6 +1245,7 @@
 				2BA345A72A6EB6BF00B7E2BD /* BaggleTagColor.swift in Sources */,
 				14E577AA2A80973300119FB3 /* EmergencyFeature.swift in Sources */,
 				2B45F2212A7B634400874783 /* MeetingDeleteType.swift in Sources */,
+				1410AD262A84BEB6008793FB /* Memeber.swift in Sources */,
 				14E506542A6B8ED3008D5778 /* SignUpSuccessView.swift in Sources */,
 				2B84696B2A6E7AE200D75D32 /* BaggleTextField.swift in Sources */,
 				149C0F482A77850A00B95A36 /* CreateSuccessView.swift in Sources */,
@@ -1245,6 +1260,7 @@
 				2BF8F9172A78DFD700510EFA /* JoinMeetingView.swift in Sources */,
 				2B84696E2A6E7AE200D75D32 /* UnderlineView.swift in Sources */,
 				1413925E2A78E66600249C8A /* CircleNumberView.swift in Sources */,
+				1410AD242A84BEA8008793FB /* Feed.swift in Sources */,
 				146C51E92A793D3F00FF3142 /* BaggleDatePickerView.swift in Sources */,
 				1493A9182A7E01D800A2D7CC /* Int+.swift in Sources */,
 				2B84696C2A6E7AE200D75D32 /* BaggleTextFieldType.swift in Sources */,

--- a/Baggle/Baggle/Core/Models/Meeting/MeetingDetail.swift
+++ b/Baggle/Baggle/Core/Models/Meeting/MeetingDetail.swift
@@ -7,6 +7,27 @@
 
 import Foundation
 
+/// 모임 상세 모델
+struct MeetingDetail: Equatable {
+    let id: Int // 모임 id
+    let name: String // 모임 이름
+    let place: String // 모임 장소
+    let date: String // 모임 날짜
+    let time: String // 모임 시간
+    let memo: String? // 메모
+    let members: [Member] // 참여자 정보
+    let status: MeetingStatus // 약속 상태
+    let isEmergencyAuthority: Bool // 긴급 버튼 권한자
+    let emergencyButtonActive: Bool // 긴급 버튼 활성화 여부
+    let emergencyButtonActiveTime: Date? // 긴급 버튼 활성화 시간
+    let isCertified: Bool
+    let feeds: [Feed]
+
+    static func == (lhs: MeetingDetail, rhs: MeetingDetail) -> Bool {
+        return lhs.id == rhs.id
+    }
+}
+
 /// 본인 포함 참여자 모델
 struct Member: Identifiable, Hashable {
     var id: Int // 유저 id
@@ -29,24 +50,4 @@ struct Feed {
     let username: String
     let userImageURL: String
     let feedImageURL: String
-}
-
-/// 모임 상세 모델
-struct MeetingDetail: Equatable {
-    let id: Int // 모임 id
-    let name: String // 모임 이름
-    let place: String // 모임 장소
-    let date: String // 모임 날짜
-    let time: String // 모임 시간
-    let memo: String? // 메모
-    let members: [Member] // 참여자 정보
-    let status: MeetingStatus // 약속 상태
-    let isEmergencyAuthority: Bool
-    let emergencyButtonActive: Bool // 긴급 버튼 활성화 여부
-    let emergencyButtonActiveTime: Date? // 긴급 버튼 활성화 시간
-    let feeds: [Feed]
-
-    static func == (lhs: MeetingDetail, rhs: MeetingDetail) -> Bool {
-        return lhs.id == rhs.id
-    }
 }

--- a/Baggle/Baggle/Core/Models/Meeting/MeetingDetail/Feed.swift
+++ b/Baggle/Baggle/Core/Models/Meeting/MeetingDetail/Feed.swift
@@ -1,0 +1,15 @@
+//
+//  Feed.swift
+//  Baggle
+//
+//  Created by youtak on 2023/08/10.
+//
+
+/// 모임 인증 피드
+struct Feed {
+    let id: Int
+    let userId: Int
+    let username: String
+    let userImageURL: String
+    let feedImageURL: String
+}

--- a/Baggle/Baggle/Core/Models/Meeting/MeetingDetail/MeetingDetail.swift
+++ b/Baggle/Baggle/Core/Models/Meeting/MeetingDetail/MeetingDetail.swift
@@ -27,27 +27,3 @@ struct MeetingDetail: Equatable {
         return lhs.id == rhs.id
     }
 }
-
-/// 본인 포함 참여자 모델
-struct Member: Identifiable, Hashable {
-    var id: Int // 유저 id
-    let name: String // 유저 이름
-    let profileURL: String // 유저 프로필 이미지 URL
-    let isMeetingAuthority: Bool // 방장 여부
-    let isButtonAuthority: Bool // 긴급 버튼 할당자 여부
-    let certified: Bool // 인증 여부
-    let certImage: String // 인증 사진, 별도 분리 가능 O
-
-    static func == (lhs: Member, rhs: Member) -> Bool {
-        return lhs.id == rhs.id
-    }
-}
-
-/// 모임 인증 피드
-struct Feed {
-    let id: Int
-    let userId: Int
-    let username: String
-    let userImageURL: String
-    let feedImageURL: String
-}

--- a/Baggle/Baggle/Core/Models/Meeting/MeetingDetail/Memeber.swift
+++ b/Baggle/Baggle/Core/Models/Meeting/MeetingDetail/Memeber.swift
@@ -1,0 +1,21 @@
+//
+//  Memeber.swift
+//  Baggle
+//
+//  Created by youtak on 2023/08/10.
+//
+
+/// 본인 포함 참여자 모델
+struct Member: Identifiable, Hashable {
+    var id: Int // 유저 id
+    let name: String // 유저 이름
+    let profileURL: String // 유저 프로필 이미지 URL
+    let isMeetingAuthority: Bool // 방장 여부
+    let isButtonAuthority: Bool // 긴급 버튼 할당자 여부
+    let certified: Bool // 인증 여부
+    let certImage: String // 인증 사진, 별도 분리 가능 O
+
+    static func == (lhs: Member, rhs: Member) -> Bool {
+        return lhs.id == rhs.id
+    }
+}

--- a/Baggle/Baggle/Core/Models/Network/MeetingDetail/MeetingDetailEntity.swift
+++ b/Baggle/Baggle/Core/Models/Network/MeetingDetail/MeetingDetailEntity.swift
@@ -36,6 +36,7 @@ extension MeetingDetailEntity {
             isEmergencyAuthority: isEmergencyAuthority(userID: userID, members: self.members),
             emergencyButtonActive: self.certificationTime != nil,
             emergencyButtonActiveTime: self.certificationTime,
+            isCertified: isCertified(userID: userID, members: self.members),
             feeds: self.members.compactMap { $0.feedDomain() }
         )
     }
@@ -63,5 +64,9 @@ extension MeetingDetailEntity {
 
     private func isEmergencyAuthority(userID: Int, members: [MeetingDetailMemberEntity]) -> Bool {
         return members.contains { $0.memberID == userID && $0.buttonAuthority }
+    }
+    
+    private func isCertified(userID: Int, members: [MeetingDetailMemberEntity]) -> Bool {
+        return members.contains { $0.memberID == userID && $0.feedID != nil }
     }
 }

--- a/Baggle/Baggle/Core/Services/MeetingDetail/MeetingDetailService.swift
+++ b/Baggle/Baggle/Core/Services/MeetingDetail/MeetingDetailService.swift
@@ -215,8 +215,8 @@ extension MockUpMeetingDetailService {
                     id: 0,
                     name: "테스트 유저1",
                     profileURL: "https://avatars.githubusercontent.com/u/71776532?v=4",
-                    isMeetingAuthority: true,
-                    isButtonAuthority: false,
+                    isMeetingAuthority: false,
+                    isButtonAuthority: true,
                     certified: false,
                     certImage: ""
                 ),
@@ -224,8 +224,8 @@ extension MockUpMeetingDetailService {
                     id: 1,
                     name: "유저2",
                     profileURL: "https://avatars.githubusercontent.com/u/81167570?v=4",
-                    isMeetingAuthority: false,
-                    isButtonAuthority: true,
+                    isMeetingAuthority: true,
+                    isButtonAuthority: false,
                     certified: false,
                     certImage: ""
                 )

--- a/Baggle/Baggle/Core/Services/MeetingDetail/MeetingDetailService.swift
+++ b/Baggle/Baggle/Core/Services/MeetingDetail/MeetingDetailService.swift
@@ -17,7 +17,8 @@ extension MeetingDetailService: DependencyKey {
     static var liveValue = Self { meetingID, userID  in
         do {
             return try await MockUpMeetingDetailService()
-                .fetchMeetingDetail(meetingID: meetingID, userID: userID)
+                .meetingDetail(status: .confirmedEmergency)
+//                .fetchMeetingDetail(meetingID: meetingID, userID: userID)
         } catch {
             return nil
         }
@@ -31,7 +32,9 @@ extension DependencyValues {
     }
 }
 
+#if DEBUG
 struct MockUpMeetingDetailService {
+
     func fetchMeetingDetail(meetingID: Int, userID: Int) async throws -> MeetingDetail {
         return try await withCheckedThrowingContinuation({ continuation in
             if let meetingEntity = mockUpJSON() {
@@ -77,3 +80,200 @@ struct MockUpMeetingDetailService {
         return entityContainer.data
     }
 }
+
+
+// MARK: - Mock Up Data
+
+
+extension MockUpMeetingDetailService {
+    
+    enum MockUpStatus {
+        case completed
+        case ready
+        case confirmed
+        case confirmedEmergency
+    }
+    
+    func meetingDetail(status: MockUpStatus) async throws -> MeetingDetail {
+        return try await withCheckedThrowingContinuation({ continuation in
+            switch status {
+            case .completed:
+                continuation.resume(returning: meetingDetailCompleted())
+            case .ready:
+                continuation.resume(returning: meetingDetailReady())
+            case .confirmed:
+                continuation.resume(returning: meetingDetailConfirm())
+            case .confirmedEmergency:
+                continuation.resume(returning: meetingDetailConfirmEmergency())
+            }
+        })
+    }
+    
+    private func meetingDetailCompleted() -> MeetingDetail {
+        MeetingDetail(
+            id: 0,
+            name: "완료된 모임",
+            place: "샌프란시스코",
+            date: "2022년 7월 31일",
+            time: "19:30",
+            memo: "슈퍼두퍼 먹자",
+            members: [
+                Member(
+                    id: 0,
+                    name: "테스트 유저1",
+                    profileURL: "https://avatars.githubusercontent.com/u/71776532?v=4",
+                    isMeetingAuthority: true,
+                    isButtonAuthority: true,
+                    certified: true,
+                    certImage: "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230327_112%2F16799270480919mNeo_JPEG%2F1679927034445.jpg"
+                    // swiftlint:disable:previous line_length
+                ),
+                Member(
+                    id: 1,
+                    name: "유저2",
+                    profileURL: "https://avatars.githubusercontent.com/u/81167570?v=4",
+                    isMeetingAuthority: false,
+                    isButtonAuthority: false,
+                    certified: true,
+                    certImage: "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230712_205%2F1689152621857ctqiJ_JPEG%2F%25C8%25A3%25C4%25BF%25BC%25BE%25C5%25CD%25BB%25E7%25C1%25F8_1.jpg"
+                    // swiftlint:disable:previous line_length
+                )
+            ],
+            status: .completed,
+            isEmergencyAuthority: true,
+            emergencyButtonActive: false,
+            emergencyButtonActiveTime: Date(timeIntervalSince1970: 1659261600),
+            isCertified: true,
+            feeds: [
+                Feed(
+                    id: 0,
+                    userId: 0,
+                    username: "테스트 유저1",
+                    userImageURL: "https://avatars.githubusercontent.com/u/71776532?v=4",
+                    feedImageURL: "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230327_112%2F16799270480919mNeo_JPEG%2F1679927034445.jpg"
+                    // swiftlint:disable:previous line_length
+                ),
+                Feed(
+                    id: 1,
+                    userId: 1,
+                    username: "유저2",
+                    userImageURL: "https://avatars.githubusercontent.com/u/81167570?v=4",
+                    feedImageURL: "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230712_205%2F1689152621857ctqiJ_JPEG%2F%25C8%25A3%25C4%25BF%25BC%25BE%25C5%25CD%25BB%25E7%25C1%25F8_1.jpg"
+                    // swiftlint:disable:previous line_length
+                )
+            ]
+        )
+    }
+
+    private func meetingDetailReady() -> MeetingDetail {
+        MeetingDetail(
+            id: 0,
+            name: "연말 모임",
+            place: "샌프란시스코",
+            date: "2024년 12월 31일",
+            time: "19:30",
+            memo: "24년 안녕~",
+            members: [
+                Member(
+                    id: 0,
+                    name: "테스트 유저1",
+                    profileURL: "https://avatars.githubusercontent.com/u/71776532?v=4",
+                    isMeetingAuthority: true,
+                    isButtonAuthority: false,
+                    certified: false,
+                    certImage: ""
+                ),
+                Member(
+                    id: 1,
+                    name: "유저2",
+                    profileURL: "https://avatars.githubusercontent.com/u/81167570?v=4",
+                    isMeetingAuthority: false,
+                    isButtonAuthority: true,
+                    certified: false,
+                    certImage: ""
+                )
+            ],
+            status: .ready,
+            isEmergencyAuthority: true,
+            emergencyButtonActive: false,
+            emergencyButtonActiveTime: Date(timeIntervalSince1970: 1735641000),
+            isCertified: false,
+            feeds: []
+        )
+    }
+
+    private func meetingDetailConfirm() -> MeetingDetail {
+        MeetingDetail(
+            id: 0,
+            name: "DND 6주차 회의",
+            place: "종각역",
+            date: "2023년 08월 13일",
+            time: "12:00",
+            memo: "점뭐먹",
+            members: [
+                Member(
+                    id: 0,
+                    name: "테스트 유저1",
+                    profileURL: "https://avatars.githubusercontent.com/u/71776532?v=4",
+                    isMeetingAuthority: true,
+                    isButtonAuthority: false,
+                    certified: false,
+                    certImage: ""
+                ),
+                Member(
+                    id: 1,
+                    name: "유저2",
+                    profileURL: "https://avatars.githubusercontent.com/u/81167570?v=4",
+                    isMeetingAuthority: false,
+                    isButtonAuthority: true,
+                    certified: false,
+                    certImage: ""
+                )
+            ],
+            status: .confirmed,
+            isEmergencyAuthority: true,
+            emergencyButtonActive: false,
+            emergencyButtonActiveTime: nil,
+            isCertified: false,
+            feeds: []
+        )
+    }
+    
+    private func meetingDetailConfirmEmergency() -> MeetingDetail {
+        MeetingDetail(
+            id: 0,
+            name: "DND 최종 발표",
+            place: "영등포",
+            date: "2023년 08월 27일",
+            time: "14:00",
+            memo: "2조 짱",
+            members: [
+                Member(
+                    id: 0,
+                    name: "테스트 유저1",
+                    profileURL: "https://avatars.githubusercontent.com/u/71776532?v=4",
+                    isMeetingAuthority: true,
+                    isButtonAuthority: false,
+                    certified: false,
+                    certImage: ""
+                ),
+                Member(
+                    id: 1,
+                    name: "유저2",
+                    profileURL: "https://avatars.githubusercontent.com/u/81167570?v=4",
+                    isMeetingAuthority: false,
+                    isButtonAuthority: true,
+                    certified: false,
+                    certImage: ""
+                )
+            ],
+            status: .confirmed,
+            isEmergencyAuthority: true,
+            emergencyButtonActive: true,
+            emergencyButtonActiveTime: Date(timeIntervalSince1970: 1693109700),
+            isCertified: false,
+            feeds: []
+        )
+    }
+}
+#endif

--- a/Baggle/Baggle/Core/Services/MeetingDetail/MeetingDetailService.swift
+++ b/Baggle/Baggle/Core/Services/MeetingDetail/MeetingDetailService.swift
@@ -17,8 +17,8 @@ extension MeetingDetailService: DependencyKey {
     static var liveValue = Self { meetingID, userID  in
         do {
             return try await MockUpMeetingDetailService()
-                .meetingDetail(status: .confirmedEmergency)
-//                .fetchMeetingDetail(meetingID: meetingID, userID: userID)
+//                .meetingDetail(status: .ready)
+                .fetchMeetingDetail(meetingID: meetingID, userID: userID)
         } catch {
             return nil
         }
@@ -188,15 +188,15 @@ extension MockUpMeetingDetailService {
                     name: "유저2",
                     profileURL: "https://avatars.githubusercontent.com/u/81167570?v=4",
                     isMeetingAuthority: false,
-                    isButtonAuthority: true,
+                    isButtonAuthority: false,
                     certified: false,
                     certImage: ""
                 )
             ],
             status: .ready,
-            isEmergencyAuthority: true,
+            isEmergencyAuthority: false,
             emergencyButtonActive: false,
-            emergencyButtonActiveTime: Date(timeIntervalSince1970: 1735641000),
+            emergencyButtonActiveTime: nil,
             isCertified: false,
             feeds: []
         )

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -43,7 +43,7 @@ struct MeetingDetailFeature: ReducerProtocol {
         var tappedImageUrl: String?
 
         // Child
-        var timerState = TimerFeature.State(targetDate: Date().later(minutes: 1).later(seconds: 10))
+        var timerState = TimerFeature.State(targetDate: Date().later(seconds: 4))
 
         // delete
         @PresentationState var selectOwner: SelectOwnerFeature.State?
@@ -240,6 +240,12 @@ struct MeetingDetailFeature: ReducerProtocol {
             case .emergencyAction:
                 return .none
 
+                // Timer
+                
+            case .timerAction(.timerOver):
+                state.buttonState = .none
+                return .none
+                
             case .timerAction:
                 return .none
 

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -122,24 +122,19 @@ struct MeetingDetailFeature: ReducerProtocol {
             case .updateData(let data):
                 state.meetingData = data
                 
-                // Temp : 버튼 뜨나 확인용
-                if data.isEmergencyAuthority {
-                    state.buttonState = .emergency
-                }
-                
                 // 약속 상태가 ready 또는 progress이면 invite
                 // 약속 상태가 confirmed이고, !emergencyButtonActive이고, 본인이 button 관리자이면 emergency
                 // 약속 상태가 confirmed이고 emergencyButtonActive이고, 본인이 !certified이면
-//                if data.status == .ready || data.status == .progress {
-//                    state.buttonState = .invite
-//                } else if data.status == .confirmed {
-//                    // 본인이 button 관리자일때 조건 추가
-//                    if !data.emergencyButtonActive {
-//                        state.buttonState = .emergency
-//                    } else if data.emergencyButtonActive && !data.certified {
-//                        state.buttonState = .authorize
-//                    }
-//                }
+                if data.status == .ready || data.status == .progress {
+                    state.buttonState = .invite
+                } else if data.status == .confirmed {
+                    // 본인이 button 관리자일때 조건 추가
+                    if !data.emergencyButtonActive && data.isEmergencyAuthority {
+                        state.buttonState = .emergency
+                    } else if data.emergencyButtonActive && !data.isCertified {
+                        state.buttonState = .authorize
+                    }
+                }
 
                 return .none
 

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -128,7 +128,6 @@ struct MeetingDetailFeature: ReducerProtocol {
                 if data.status == .ready || data.status == .progress {
                     state.buttonState = .invite
                 } else if data.status == .confirmed {
-                    // 본인이 button 관리자일때 조건 추가
                     if !data.emergencyButtonActive && data.isEmergencyAuthority {
                         state.buttonState = .emergency
                     } else if data.emergencyButtonActive && !data.isCertified {

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
@@ -334,24 +334,8 @@ struct MeetingDetailView_Previews: PreviewProvider {
             store: Store(
                 initialState: MeetingDetailFeature.State(
                     userID: 1,
-                    meetingId: 12345,
-                    meetingData: MeetingDetail(
-                        // swiftlint:disable:next multiline_arguments
-                        id: 100, name: "모임방1000", place: "강남역",
-                        // swiftlint:disable:next multiline_arguments
-                        date: "2023년 4월 9일", time: "16:40", memo: "ㅇㅇ",
-                        members: [Member(
-                            // swiftlint:disable:next multiline_arguments
-                            id: 1, name: "콩이", profileURL: "",
-                            // swiftlint:disable:next multiline_arguments line_length
-                            isMeetingAuthority: true, isButtonAuthority: false, certified: false, certImage: "")],
-                        status: .confirmed,
-                        isEmergencyAuthority: false,
-                        // swiftlint:disable:next multiline_arguments
-                        emergencyButtonActive: false,
-                        emergencyButtonActiveTime: nil,
-                        isCertified: false,
-                        feeds: [])),
+                    meetingId: 12345
+                ),
                 reducer: MeetingDetailFeature()
             )
         )

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
@@ -70,6 +70,8 @@ struct MeetingDetailView: View {
                             .padding(.bottom, 16)
                     }
                 }
+                .animation(.easeOut(duration: 0.3), value: viewStore.buttonState)
+                .transition(.move(edge: .bottom))
 
                 // alert
                 if viewStore.isAlertPresented {

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
@@ -348,7 +348,9 @@ struct MeetingDetailView_Previews: PreviewProvider {
                         status: .confirmed,
                         isEmergencyAuthority: false,
                         // swiftlint:disable:next multiline_arguments
-                        emergencyButtonActive: false, emergencyButtonActiveTime: nil,
+                        emergencyButtonActive: false,
+                        emergencyButtonActiveTime: nil,
+                        isCertified: false,
                         feeds: [])),
                 reducer: MeetingDetailFeature()
             )

--- a/Baggle/BaggleTests/TestDateService.swift
+++ b/Baggle/BaggleTests/TestDateService.swift
@@ -22,7 +22,7 @@ struct TestDateService {
 
         return date
     }
-    
+
     // MARK: - 목업 Meeting Status 생성
     // 특정 시간(meetingTime)을 인자로 받아 Meeting Status 생성
     


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #112 

## 내용
<!--
로직 설명  
--> 
- 수빈님이 작성한 버튼 로직을 활성화했습니다. 
  `MeetingDetail`에 `isCertified` 프로퍼티를 추가했습니다. `Meeting Detail Entity`에서 `Feed`를 순회하며 `isCertified` 여부를 확인합니다.
- `MockUpMeetingDetailService`에서 목업 모델을 생성하는 함수를 만들어 상태에 따른 버튼 로직을 확인했습니다.
   시간에 종속되지 않을라고 모델을 일일이 만들었습니다. 로직에 문제가 있는지 확인해주세요.
   ex) `status = .ready`인데 `emergencyButtonActive: true` 인 경우

- 아래와 같이 함수를 사용해주시면 됩니다.
   ``` swift
   try await MockUpMeetingDetailService().meetingDetail(status: .confirmedEmergency)  
   // completed, ready, confirmed, confirmedEmergency
   ```
   
- 타이머가 종료될 때, 이벤트를 받아 버튼을 제거해줍니다. 에니메이션을 적용했습니다.


### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

|completed|ready|confirmed (비상 버튼 전)|confirmed (비상 버튼 누르고)|
|:---:|:---:|:---:|:---:|
|<img width = 220 src = "https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/27505074-861e-4b76-862e-5bab1021e3ef" />|<img width = 220 src = "https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/e311dfb1-d03f-41fc-ba08-9ced2cd053cd" />|<img width = 220 src = "https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/369063b2-4188-4595-8616-ab6bd6cbba05" />|<img width = 220 src = "https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/608b27f5-d338-427c-b2a2-835f727c778f" />|


시간 경과되면 인증 버튼 사라지기

![Simulator Screen Recording - iPhone 14 Pro - 2023-08-10 at 17 08 20](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/0e2423c7-07f2-46bb-b59a-0e69e17d2fac)


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- 실제 시간 로직이 들어가서 테스트가 쉽지 않네요 🫠

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
