### PR TITLE
모임상세 타이머 버튼 & 카메라 타이머 연동

### DIFF
--- a/Baggle/Baggle/Core/Common/Extensions/Date/Date+.swift
+++ b/Baggle/Baggle/Core/Common/Extensions/Date/Date+.swift
@@ -307,6 +307,12 @@ extension Date {
 
 // MARK: - 타이머
 extension Date {
+
+    func authenticationTimeout() -> Int {
+        self.later(minutes: 5).remainingTime()
+    }
+    
+    
     func remainingTime() -> Int {
         let components = calendar.dateComponents([.second], from: Date(), to: self)
         if let result = components.second, result > 0 {

--- a/Baggle/Baggle/Core/Common/Extensions/Date/Date+.swift
+++ b/Baggle/Baggle/Core/Common/Extensions/Date/Date+.swift
@@ -322,3 +322,14 @@ extension Date {
         }
     }
 }
+
+
+#if DEBUG
+extension Date {
+    static func createDate(_ year: Int, _ month: Int, _ day: Int, _ hour: Int, _ minute: Int) -> Date {
+        let targetDateComponents = DateComponents(year: year, month: month, day: day, hour: hour, minute: minute)
+        let targetDate = Calendar.current.date(from: targetDateComponents)
+        return targetDate!
+    }
+}
+#endif

--- a/Baggle/Baggle/Core/Services/MeetingDetail/MeetingDetailService.swift
+++ b/Baggle/Baggle/Core/Services/MeetingDetail/MeetingDetailService.swift
@@ -17,8 +17,8 @@ extension MeetingDetailService: DependencyKey {
     static var liveValue = Self { meetingID, userID  in
         do {
             return try await MockUpMeetingDetailService()
-//                .meetingDetail(status: .ready)
-                .fetchMeetingDetail(meetingID: meetingID, userID: userID)
+                .meetingDetail(status: .confirmedEmergency)
+//                .fetchMeetingDetail(meetingID: meetingID, userID: userID)
         } catch {
             return nil
         }
@@ -244,8 +244,8 @@ extension MockUpMeetingDetailService {
             id: 0,
             name: "DND 최종 발표",
             place: "영등포",
-            date: "2023년 08월 27일",
-            time: "14:00",
+            date: "2023년 08월 11일",
+            time: "13:45",
             memo: "2조 짱",
             members: [
                 Member(
@@ -270,7 +270,7 @@ extension MockUpMeetingDetailService {
             status: .confirmed,
             isEmergencyAuthority: true,
             emergencyButtonActive: true,
-            emergencyButtonActiveTime: Date(timeIntervalSince1970: 1693109700),
+            emergencyButtonActiveTime: Date.createDate(2023, 8, 11, 13, 48),
             isCertified: false,
             feeds: []
         )

--- a/Baggle/Baggle/Core/Services/MeetingDetail/MeetingDetailService.swift
+++ b/Baggle/Baggle/Core/Services/MeetingDetail/MeetingDetailService.swift
@@ -270,7 +270,7 @@ extension MockUpMeetingDetailService {
             status: .confirmed,
             isEmergencyAuthority: true,
             emergencyButtonActive: true,
-            emergencyButtonActiveTime: Date.createDate(2023, 8, 11, 13, 48),
+            emergencyButtonActiveTime: Date.createDate(2023, 8, 11, 13, 30),
             isCertified: false,
             feeds: []
         )

--- a/Baggle/Baggle/Features/Camera/CameraFeature.swift
+++ b/Baggle/Baggle/Features/Camera/CameraFeature.swift
@@ -22,7 +22,7 @@ struct CameraFeature: ReducerProtocol {
         var isCompleted: Bool = false
 
         // Timer
-        var timer = TimerFeature.State()
+        var timer = TimerFeature.State(timerCount: 30)
         var isTimeOver: Bool = false
     }
 

--- a/Baggle/Baggle/Features/Camera/CameraFeature.swift
+++ b/Baggle/Baggle/Features/Camera/CameraFeature.swift
@@ -22,7 +22,7 @@ struct CameraFeature: ReducerProtocol {
         var isCompleted: Bool = false
 
         // Timer
-        var timer = TimerFeature.State(timerCount: 30)
+        var timer: TimerFeature.State
         var isTimeOver: Bool = false
     }
 

--- a/Baggle/Baggle/Features/Common/Timer/LargeTimerView.swift
+++ b/Baggle/Baggle/Features/Common/Timer/LargeTimerView.swift
@@ -59,7 +59,7 @@ struct LargeTimerView_Previews: PreviewProvider {
     static var previews: some View {
         LargeTimerView(
             store: Store(
-                initialState: TimerFeature.State(),
+                initialState: TimerFeature.State(timerCount: 30),
                 reducer: TimerFeature()
             )
         )

--- a/Baggle/Baggle/Features/Common/Timer/LargeTimerView.swift
+++ b/Baggle/Baggle/Features/Common/Timer/LargeTimerView.swift
@@ -49,7 +49,10 @@ struct LargeTimerView: View {
             .cornerRadius(12)
             .animation(.easeInOut(duration: 0.3), value: viewStore.isTimerOver)
             .onAppear {
-                viewStore.send(.onAppear)
+                viewStore.send(.start)
+            }
+            .onDisappear {
+                viewStore.send(.cancel)
             }
         }
     }

--- a/Baggle/Baggle/Features/Common/Timer/SmallTimerView.swift
+++ b/Baggle/Baggle/Features/Common/Timer/SmallTimerView.swift
@@ -33,7 +33,10 @@ struct SmallTimerView: View {
             .background(Color.primaryNormal)
             .cornerRadius(20)
             .onAppear {
-                viewStore.send(.onAppear)
+                viewStore.send(.start)
+            }
+            .onDisappear {
+                viewStore.send(.cancel)
             }
         }
     }

--- a/Baggle/Baggle/Features/Common/Timer/SmallTimerView.swift
+++ b/Baggle/Baggle/Features/Common/Timer/SmallTimerView.swift
@@ -43,7 +43,7 @@ struct SmallTimerView_Previews: PreviewProvider {
     static var previews: some View {
         SmallTimerView(
             store: Store(
-                initialState: TimerFeature.State(),
+                initialState: TimerFeature.State(timerCount: 30),
                 reducer: TimerFeature()
             )
         )

--- a/Baggle/Baggle/Features/Common/Timer/TimerFeature.swift
+++ b/Baggle/Baggle/Features/Common/Timer/TimerFeature.swift
@@ -12,9 +12,7 @@ import ComposableArchitecture
 struct TimerFeature: ReducerProtocol {
 
     struct State: Equatable {
-        var targetDate: Date = Date().later(seconds: 3)
-
-        var timerCount: Int = 0
+        var timerCount: Int
         var isTimerOver: Bool = false
     }
 
@@ -38,7 +36,6 @@ struct TimerFeature: ReducerProtocol {
 
             switch action {
             case .onAppear:
-                state.timerCount = state.targetDate.remainingTime()
 
                 if state.timerCount <= 0 {
                     return .run { send in await send(.timerOver)}

--- a/Baggle/Baggle/Features/Common/Timer/TimerFeature.swift
+++ b/Baggle/Baggle/Features/Common/Timer/TimerFeature.swift
@@ -17,8 +17,9 @@ struct TimerFeature: ReducerProtocol {
     }
 
     enum Action: Equatable {
-        case onAppear
-
+        case start
+        case cancel
+        
         // MARK: - Timer
 
         case timerTick
@@ -35,8 +36,8 @@ struct TimerFeature: ReducerProtocol {
         Reduce { state, action in
 
             switch action {
-            case .onAppear:
-
+            case .start:
+                
                 if state.timerCount <= 0 {
                     return .run { send in await send(.timerOver)}
                 }
@@ -47,6 +48,9 @@ struct TimerFeature: ReducerProtocol {
                     }
                 }
                 .cancellable(id: CancelID.timer)
+                
+            case .cancel:
+                return .cancel(id: CancelID.timer)
                 // MARK: - Timer
 
             case .timerTick:

--- a/Baggle/Baggle/Features/MeetingDetail/Emergency/EmergencyFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/Emergency/EmergencyFeature.swift
@@ -15,7 +15,7 @@ struct EmergencyFeature: ReducerProtocol {
         var isEmergency: Bool = false
 
         // Child
-        var timerState = TimerFeature.State(targetDate: Date().later(minutes: 1).later(seconds: 10))
+        var timerState = TimerFeature.State(timerCount: 30)
     }
 
     enum Action: Equatable {

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -43,7 +43,7 @@ struct MeetingDetailFeature: ReducerProtocol {
         var tappedImageUrl: String?
 
         // Child
-        var timerState = TimerFeature.State(targetDate: Date().later(seconds: 4))
+        var timerState = TimerFeature.State(timerCount: 30)
 
         // delete
         @PresentationState var selectOwner: SelectOwnerFeature.State?

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -268,6 +268,8 @@ struct MeetingDetailFeature: ReducerProtocol {
                     print("언래핑 에러")
                 }
                 
+                // button의 onAppear 때 타이머 시작이 되기 때문에, 타이머 시간을 설정하고 버튼이 나타나야함
+                // 아니면 버튼이 바로 사라짐
                 state.buttonState = .authorize
 
                 return .none

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -172,7 +172,14 @@ struct MeetingDetailFeature: ReducerProtocol {
                 return .none
 
             case .cameraButtonTapped:
-                state.usingCamera = CameraFeature.State()
+                if let emergencyButtonActiveTime = state.meetingData?.emergencyButtonActiveTime {
+                    let timerCount = emergencyButtonActiveTime.authenticationTimeout()
+                    state.usingCamera = CameraFeature.State(
+                        timer: TimerFeature.State(timerCount: timerCount)
+                    )
+                } else {
+                    print("언래핑 에러")
+                }
                 return .none
 
             case .emergencyButtonTapped:

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -43,7 +43,7 @@ struct MeetingDetailFeature: ReducerProtocol {
         var tappedImageUrl: String?
 
         // Child
-        var timerState = TimerFeature.State(timerCount: 30)
+        var timerState = TimerFeature.State(timerCount: 0)
 
         // delete
         @PresentationState var selectOwner: SelectOwnerFeature.State?
@@ -85,6 +85,9 @@ struct MeetingDetailFeature: ReducerProtocol {
         case emergencyAction(PresentationAction<EmergencyFeature.Action>)
         case timerAction(TimerFeature.Action)
 
+        // Timer - State
+        case timerCountChanged
+        
         // delegate
         case delegate(Delegate)
 
@@ -131,7 +134,7 @@ struct MeetingDetailFeature: ReducerProtocol {
                     if !data.emergencyButtonActive && data.isEmergencyAuthority {
                         state.buttonState = .emergency
                     } else if data.emergencyButtonActive && !data.isCertified {
-                        state.buttonState = .authorize
+                        return .run { send in await send(.timerCountChanged) }
                     }
                 }
 
@@ -240,7 +243,7 @@ struct MeetingDetailFeature: ReducerProtocol {
             case .emergencyAction:
                 return .none
 
-                // Timer
+                // Child - Timer
                 
             case .timerAction(.timerOver):
                 state.buttonState = .none
@@ -249,6 +252,19 @@ struct MeetingDetailFeature: ReducerProtocol {
             case .timerAction:
                 return .none
 
+                // Timer - State
+                
+            case .timerCountChanged:
+                if let emergencyButtonActiveTime = state.meetingData?.emergencyButtonActiveTime {
+                    state.timerState.timerCount = emergencyButtonActiveTime.authenticationTimeout()
+                } else {
+                    print("언래핑 에러")
+                }
+                
+                state.buttonState = .authorize
+
+                return .none
+                
                 // Delegate
 
             case .delegate(.deleteSuccess):

--- a/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
@@ -158,7 +158,9 @@ struct HomeFeature: ReducerProtocol {
                 return .none
 
             case .cameraButtonTapped:
-                state.usingCamera = CameraFeature.State()
+                state.usingCamera = CameraFeature.State(
+                    timer: TimerFeature.State(timerCount: 30)
+                )
                 return .none
 
             case .usingCamera:

--- a/Baggle/Baggle/Sources/BaggleApp.swift
+++ b/Baggle/Baggle/Sources/BaggleApp.swift
@@ -26,7 +26,7 @@ struct BaggleApp: App {
             AppView(
                 store: Store(
                     initialState: AppFeature.State(
-                        isLoggedIn: false,
+                        isLoggedIn: true,
                         loginFeature: LoginFeature.State(),
                         mainTabFeature: MainTabFeature.State(
                             selectedTab: .home,


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #114

## 내용
<!--
로직 설명  
--> 
- 긴급 버튼 누른 시간을 기준으로 타이머를 동작시킵니다. `emergencyButtonActiveTime` + 5분까지 남은 시간을 Timer에 주입해줍니다. 타이머는 제목 그대로 남은 시간까지 타이머의 역할을 한다고 생각해서, 외부에서 남은시간을 계산해서 주입해주었습니다.
- 버튼 타이머 -> 카메라 타이머를 연동했습니다. 타이머 완료 로직까지 처리 완료했습니다.

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

![Simulator Screen Recording - iPhone 14 Pro - 2023-08-11 at 13 54 28](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/033bf962-1fda-45f7-a881-884f2412af5d)

![Simulator Screen Recording - iPhone 14 Pro - 2023-08-11 at 13 58 02](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/3b01013f-7d3c-4f4f-aba2-fd4a88b97342)

영상에서는 화면이 내려가고 타이머가 남아있는데 gif가 반복되서 그렇습니다. 카메라 화면에서 타이머 완료되면 실제로는 모임 상세 버튼도 사라집니다.

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- 언래핑할 때 Alert으로 에러 처리가 필요할 것 같아요.

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
