### PR TITLE
Feature - 로그인 API 연결

### DIFF
--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		141392622A78EBD300249C8A /* CreateStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141392612A78EBD300249C8A /* CreateStatus.swift */; };
 		141D376F2A681552001067E3 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141D376E2A681552001067E3 /* MainTabView.swift */; };
 		141D37712A681569001067E3 /* MainTabFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141D37702A681569001067E3 /* MainTabFeature.swift */; };
-		1421C0512A7A84A200C20497 /* KakaoLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1421C0502A7A84A200C20497 /* KakaoLoginService.swift */; };
+		1421C0512A7A84A200C20497 /* LoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1421C0502A7A84A200C20497 /* LoginService.swift */; };
 		142BF96D2A81F50C0042737E /* TimerColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142BF96C2A81F50C0042737E /* TimerColor.swift */; };
 		14315D862A76B1CB008F8064 /* CreateMemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14315D852A76B1CB008F8064 /* CreateMemoView.swift */; };
 		1432BE642A68168A0098AAA9 /* TabType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1432BE632A68168A0098AAA9 /* TabType.swift */; };
@@ -108,11 +108,12 @@
 		2B5BE6B22A77A40900F25474 /* MeetingDetailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5BE6B12A77A40900F25474 /* MeetingDetailService.swift */; };
 		2B5CF2682A6EC889004D3033 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5CF2672A6EC889004D3033 /* View+.swift */; };
 		2B604DDA2A7F60E7000E2DE2 /* CircleProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B604DD92A7F60E7000E2DE2 /* CircleProfileView.swift */; };
+		2B65B8132A8758E900E3BF11 /* LoginRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B65B8122A8758E900E3BF11 /* LoginRequestModel.swift */; };
 		2B7B4D6B2A849E9D00283248 /* BaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7B4D6A2A849E9D00283248 /* BaseService.swift */; };
 		2B7B4D6E2A84A1FF00283248 /* DefaultAlamofireManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7B4D6D2A84A1FF00283248 /* DefaultAlamofireManager.swift */; };
 		2B7B4D722A84A5C800283248 /* Meeting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7B4D702A84A5C800283248 /* Meeting.swift */; };
 		2B7B4D742A84A5EC00283248 /* ProfileImageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7B4D732A84A5EC00283248 /* ProfileImageModel.swift */; };
-		2B7B4D772A84B41000283248 /* SignUpEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7B4D762A84B41000283248 /* SignUpEntity.swift */; };
+		2B7B4D772A84B41000283248 /* SignEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7B4D762A84B41000283248 /* SignEntity.swift */; };
 		2B7B4D7B2A85342600283248 /* MeetingDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7B4D6F2A84A5C800283248 /* MeetingDetail.swift */; };
 		2B7B4D7D2A853BED00283248 /* MeetingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7B4D7C2A853BED00283248 /* MeetingAPI.swift */; };
 		2B7B4D7F2A853E8800283248 /* MemberAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7B4D7E2A853E8800283248 /* MemberAPI.swift */; };
@@ -187,7 +188,7 @@
 		141392612A78EBD300249C8A /* CreateStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateStatus.swift; sourceTree = "<group>"; };
 		141D376E2A681552001067E3 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		141D37702A681569001067E3 /* MainTabFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabFeature.swift; sourceTree = "<group>"; };
-		1421C0502A7A84A200C20497 /* KakaoLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginService.swift; sourceTree = "<group>"; };
+		1421C0502A7A84A200C20497 /* LoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginService.swift; sourceTree = "<group>"; };
 		142BF96C2A81F50C0042737E /* TimerColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerColor.swift; sourceTree = "<group>"; };
 		14315D852A76B1CB008F8064 /* CreateMemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMemoView.swift; sourceTree = "<group>"; };
 		1432BE632A68168A0098AAA9 /* TabType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabType.swift; sourceTree = "<group>"; };
@@ -271,12 +272,13 @@
 		2B5BE6B12A77A40900F25474 /* MeetingDetailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDetailService.swift; sourceTree = "<group>"; };
 		2B5CF2672A6EC889004D3033 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		2B604DD92A7F60E7000E2DE2 /* CircleProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleProfileView.swift; sourceTree = "<group>"; };
+		2B65B8122A8758E900E3BF11 /* LoginRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRequestModel.swift; sourceTree = "<group>"; };
 		2B7B4D6A2A849E9D00283248 /* BaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseService.swift; sourceTree = "<group>"; };
 		2B7B4D6D2A84A1FF00283248 /* DefaultAlamofireManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAlamofireManager.swift; sourceTree = "<group>"; };
 		2B7B4D6F2A84A5C800283248 /* MeetingDetail.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MeetingDetail.swift; path = Baggle/Core/Models/Meeting/MeetingDetail/MeetingDetail.swift; sourceTree = SOURCE_ROOT; };
 		2B7B4D702A84A5C800283248 /* Meeting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Meeting.swift; path = Baggle/Core/Models/Meeting/Meeting.swift; sourceTree = SOURCE_ROOT; };
 		2B7B4D732A84A5EC00283248 /* ProfileImageModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileImageModel.swift; sourceTree = "<group>"; };
-		2B7B4D762A84B41000283248 /* SignUpEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SignUpEntity.swift; path = Baggle/Core/Models/Network/SignUp/SignUpEntity.swift; sourceTree = SOURCE_ROOT; };
+		2B7B4D762A84B41000283248 /* SignEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SignEntity.swift; path = Baggle/Core/Models/Network/SignUp/SignEntity.swift; sourceTree = SOURCE_ROOT; };
 		2B7B4D7C2A853BED00283248 /* MeetingAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingAPI.swift; sourceTree = "<group>"; };
 		2B7B4D7E2A853E8800283248 /* MemberAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberAPI.swift; sourceTree = "<group>"; };
 		2B7B4D802A853ED300283248 /* FeedAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedAPI.swift; sourceTree = "<group>"; };
@@ -526,7 +528,7 @@
 		1421C04F2A7A848E00C20497 /* Login */ = {
 			isa = PBXGroup;
 			children = (
-				1421C0502A7A84A200C20497 /* KakaoLoginService.swift */,
+				1421C0502A7A84A200C20497 /* LoginService.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -792,7 +794,7 @@
 			children = (
 				2BC5AD302A84983C00B73241 /* SignUpRequestModel.swift */,
 				2B7B4D732A84A5EC00283248 /* ProfileImageModel.swift */,
-				2B7B4D762A84B41000283248 /* SignUpEntity.swift */,
+				2B7B4D762A84B41000283248 /* SignEntity.swift */,
 			);
 			name = SignUp;
 			path = ../SignUp;
@@ -804,6 +806,7 @@
 				14E083692A83690D0001CB21 /* EntityContainer.swift */,
 				14E0836B2A8369E30001CB21 /* MeetingDetail */,
 				14E083672A8368F70001CB21 /* SignUp */,
+				2B65B8112A8758DB00E3BF11 /* Login */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -968,6 +971,14 @@
 				2B5BE6B12A77A40900F25474 /* MeetingDetailService.swift */,
 			);
 			path = MeetingDetail;
+			sourceTree = "<group>";
+		};
+		2B65B8112A8758DB00E3BF11 /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				2B65B8122A8758E900E3BF11 /* LoginRequestModel.swift */,
+			);
+			path = Login;
 			sourceTree = "<group>";
 		};
 		2B7B4D6C2A84A1F200283248 /* Network */ = {
@@ -1292,11 +1303,12 @@
 				2BC5AD2F2A84938600B73241 /* UserAPI.swift in Sources */,
 				14EDE63E2A77A2AD0004F72B /* SignUpSuccessFeature.swift in Sources */,
 				141D376F2A681552001067E3 /* MainTabView.swift in Sources */,
+				2B65B8132A8758E900E3BF11 /* LoginRequestModel.swift in Sources */,
 				2B2BA52D2A7ABBA000A90AE7 /* MemberInfoView.swift in Sources */,
 				14783EDF2A7E2FBD00EF58D5 /* CameraSetting.swift in Sources */,
 				2B8469712A6E7AE200D75D32 /* BaggleButtonStyle.swift in Sources */,
 				14E506582A6BC576008D5778 /* MyPageFeature.swift in Sources */,
-				2B7B4D772A84B41000283248 /* SignUpEntity.swift in Sources */,
+				2B7B4D772A84B41000283248 /* SignEntity.swift in Sources */,
 				2BB6BA902A82039300F04188 /* MeetingDetailButtonType.swift in Sources */,
 				1461B6002A7BA3F000A15706 /* BubbleView.swift in Sources */,
 				2B84696D2A6E7AE200D75D32 /* ShadeView.swift in Sources */,
@@ -1307,7 +1319,7 @@
 				2B3B64952A8014540082A05F /* FeedListCell.swift in Sources */,
 				141D37712A681569001067E3 /* MainTabFeature.swift in Sources */,
 				2B8469702A6E7AE200D75D32 /* BaggleButtonType.swift in Sources */,
-				1421C0512A7A84A200C20497 /* KakaoLoginService.swift in Sources */,
+				1421C0512A7A84A200C20497 /* LoginService.swift in Sources */,
 				2B2E7E482A848EC60033C65A /* BaseAPI.swift in Sources */,
 				14458B442A81E6D000C810FA /* BaggleStamp.swift in Sources */,
 				2B30E33E2A6F9DF000949151 /* UserDefaultKeyList.swift in Sources */,

--- a/Baggle/Baggle/Core/API/UserAPI.swift
+++ b/Baggle/Baggle/Core/API/UserAPI.swift
@@ -11,7 +11,7 @@ import Alamofire
 import Moya
 
 enum UserAPI {
-    case signIn
+    case signIn(requestModel: LoginRequestModel, token: String)
     case signUp(requestModel: SignUpRequestModel, token: String)
     case reissue
 }
@@ -34,8 +34,8 @@ extension UserAPI: BaseAPI {
     
     var headers: [String: String]? {
         switch self {
-        case .signIn:
-            return HeaderType.jsonWithAuthorization(token: "").value // 카카오 또는 애플 토큰
+        case .signIn(_, let token):
+            return HeaderType.jsonWithAuthorization(token: token).value // 카카오 또는 애플 토큰
         case .signUp(_, let token):
             return HeaderType.multipart(token: token).value // 카카오 또는 애플 토큰
         case .reissue:
@@ -60,6 +60,9 @@ extension UserAPI: BaseAPI {
         var params: Parameters = [:]
         
         switch self {
+        case .signIn(let requestModel, _):
+            params["platform"] = requestModel.platform.rawValue
+            params["fcmToken"] = requestModel.fcmToken
         default:
             break
         }
@@ -76,6 +79,9 @@ extension UserAPI: BaseAPI {
     
     var task: Moya.Task {
         switch self {
+        case .signIn:
+            return .requestParameters(parameters: bodyParameters ?? [:],
+                                      encoding: parameterEncoding)
         case .signUp(let requestModel, _):
             var multiPartData: [Moya.MultipartFormData] = []
             let profileImageData = MultipartFormData(
@@ -99,7 +105,7 @@ extension UserAPI: BaseAPI {
             
             return .uploadMultipart(multiPartData)
             
-        case .signIn, .reissue:
+        case .reissue:
             return .requestPlain
         }
     }

--- a/Baggle/Baggle/Core/API/UserAPI.swift
+++ b/Baggle/Baggle/Core/API/UserAPI.swift
@@ -111,7 +111,7 @@ extension UserAPI: BaseAPI {
             
             return .uploadMultipart(multiPartData)
             
-        case .reissue:
+        case .reissue, .withdraw:
             return .requestPlain
         }
     }

--- a/Baggle/Baggle/Core/Models/Network/Login/LoginRequestModel.swift
+++ b/Baggle/Baggle/Core/Models/Network/Login/LoginRequestModel.swift
@@ -1,0 +1,13 @@
+//
+//  LoginRequestModel.swift
+//  Baggle
+//
+//  Created by 양수빈 on 2023/08/12.
+//
+
+import Foundation
+
+struct LoginRequestModel {
+    let platform: LoginPlatform
+    let fcmToken: String
+}

--- a/Baggle/Baggle/Core/Models/Network/SignUp/SignEntity.swift
+++ b/Baggle/Baggle/Core/Models/Network/SignUp/SignEntity.swift
@@ -1,5 +1,5 @@
 //
-//  SignUpEntity.swift
+//  LoginEntity.swift
 //  Baggle
 //
 //  Created by 양수빈 on 2023/08/10.
@@ -7,7 +7,8 @@
 
 import Foundation
 
-struct SignUpEntity: Codable {
+/// SignUp, SignIn에서 공통으로 사용되는 Entity입니다.
+struct SignEntity: Codable {
     let accessToken: String
     let refreshToken: String
     let platform: String
@@ -22,6 +23,11 @@ struct SignUpEntity: Codable {
     }
 }
 
-extension SignUpEntity {
-    // User 모델로
+extension SignEntity {
+    func toDomain() -> User {
+        return User(id: userID,
+                    name: nickname,
+                    profileImageURL: profileImageUrl,
+                    platform: platform == "kakao" ? .kakao : .apple)
+    }
 }

--- a/Baggle/Baggle/Core/Services/Common/BaseService.swift
+++ b/Baggle/Baggle/Core/Services/Common/BaseService.swift
@@ -62,6 +62,8 @@ extension BaseService {
                             }
                         case 400:
                             continuation.resume(throwing: APIError.badRequest)
+                        case 401:
+                            continuation.resume(throwing: APIError.unauthorized)
                         case 404:
                             continuation.resume(throwing: APIError.notFound)
                         case 409:

--- a/Baggle/Baggle/Core/Services/Common/BaseService.swift
+++ b/Baggle/Baggle/Core/Services/Common/BaseService.swift
@@ -53,7 +53,7 @@ extension BaseService {
                         let body = try decoder.decode(EntityContainer<T>.self, from: response.data)
                         print("✅ response -", body)
                         switch body.status {
-                        case 201:
+                        case 200, 201:
                             if let data = body.data {
                                 print("✅ data -", data)
                                 continuation.resume(returning: data)
@@ -62,6 +62,8 @@ extension BaseService {
                             }
                         case 400:
                             continuation.resume(throwing: APIError.badRequest)
+                        case 404:
+                            continuation.resume(throwing: APIError.notFound)
                         case 409:
                             if body.message == "이미 존재하는 닉네임입니다." {
                                 continuation.resume(throwing: APIError.duplicatedNickname)

--- a/Baggle/Baggle/Core/Services/Error/APIError.swift
+++ b/Baggle/Baggle/Core/Services/Error/APIError.swift
@@ -10,6 +10,7 @@ import Foundation
 enum APIError: Error, Equatable {
     case badRequest // 400
     case unauthorized // 401, 소셜로그인 에러
+    case notFound // 404, 리소스 또는 유저 정보 없음
     case duplicatedUser // 409, 이미 존재하는 회원
     case duplicatedNickname // 409, 닉네임 중복
     case server // 500

--- a/Baggle/Baggle/Core/Services/Error/APIError.swift
+++ b/Baggle/Baggle/Core/Services/Error/APIError.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum APIError: Error, Equatable {
     case badRequest // 400
-    case unauthorized // 401, 소셜로그인 에러
+    case unauthorized // 401, 토큰 에러
     case notFound // 404, 리소스 또는 유저 정보 없음
     case duplicatedUser // 409, 이미 존재하는 회원
     case duplicatedNickname // 409, 닉네임 중복

--- a/Baggle/Baggle/Core/Services/Login/LoginService.swift
+++ b/Baggle/Baggle/Core/Services/Login/LoginService.swift
@@ -10,15 +10,44 @@ import Foundation
 import ComposableArchitecture
 import KakaoSDKUser
 
-struct KakaoLoginService {
-    var login: () async throws -> String
+enum LoginServiceState {
+    case success
+    case requireSignUp
+    case fail(APIError)
 }
 
-extension KakaoLoginService: DependencyKey {
+struct LoginService {
+    var login: (LoginRequestModel, String) async -> LoginServiceState
+    var kakaoLogin: () async throws -> String
+}
 
+extension LoginService: DependencyKey {
+    
+    static let networkService = BaseService<UserAPI>()
     typealias TokenContinuation = CheckedContinuation<String, Error>
 
-    static var liveValue = Self {
+    static var liveValue = Self { requestModel, token in
+        do {
+            let data: SignEntity = try await networkService.request(.signIn(
+                requestModel: requestModel,
+                token: token))
+            let token = UserToken(accessToken: data.accessToken, refreshToken: data.refreshToken)
+            if KeychainManager.shared.readUserToken() == nil {
+                try KeychainManager.shared.deleteUserToken()
+            }
+            try KeychainManager.shared.createUserToken(token)
+            
+            UserDefaultList.user = data.toDomain()
+            return .success
+        } catch let error {
+            print("LoginService - error: \(error)")
+            if (error as? APIError) == APIError.notFound {
+                return .requireSignUp
+            } else {
+                return .fail(.network)
+            }
+        }
+    } kakaoLogin: {
         return try await withCheckedThrowingContinuation({ (continuation: TokenContinuation) in
             DispatchQueue.main.async {
                 if UserApi.isKakaoTalkLoginAvailable() {
@@ -50,8 +79,8 @@ extension KakaoLoginService: DependencyKey {
 }
 
 extension DependencyValues {
-    var kakaoLoginService: KakaoLoginService {
-        get { self[KakaoLoginService.self] }
-        set { self[KakaoLoginService.self] = newValue }
+    var loginService: LoginService {
+        get { self[LoginService.self] }
+        set { self[LoginService.self] = newValue }
     }
 }

--- a/Baggle/Baggle/Core/Services/Login/LoginService.swift
+++ b/Baggle/Baggle/Core/Services/Login/LoginService.swift
@@ -41,8 +41,13 @@ extension LoginService: DependencyKey {
             return .success
         } catch let error {
             print("LoginService - error: \(error)")
-            if (error as? APIError) == APIError.notFound {
+            guard let error = error as? APIError else { return .fail(.network) }
+            
+            if error == .notFound {
                 return .requireSignUp
+            } else if error == .unauthorized {
+                // 리프레시 토큰으로 재로그인 요청
+                return .fail(.network)
             } else {
                 return .fail(.network)
             }

--- a/Baggle/Baggle/Core/Services/SignUp/SignUpService.swift
+++ b/Baggle/Baggle/Core/Services/SignUp/SignUpService.swift
@@ -49,7 +49,7 @@ struct SignUpRepository {
         print("📍requestModel: \(requestModel)")
         
         do {
-            let data: SignUpEntity = try await networkService.request(.signUp(
+            let data: SignEntity = try await networkService.request(.signUp(
                 requestModel: requestModel,
                 token: token))
             print("data: \(data)")
@@ -60,10 +60,7 @@ struct SignUpRepository {
             }
             try KeychainManager.shared.createUserToken(token)
 
-            UserDefaultList.user = User(id: data.userID,
-                                        name: data.nickname,
-                                        profileImageURL: data.profileImageUrl,
-                                        platform: data.platform == "apple" ? .apple : .kakao)
+            UserDefaultList.user = data.toDomain()
             return .success
         } catch let error {
             print("SignUpRepository - error: \(error)")

--- a/Baggle/Baggle/Core/Services/SignUp/SignUpService.swift
+++ b/Baggle/Baggle/Core/Services/SignUp/SignUpService.swift
@@ -28,7 +28,7 @@ extension SignUpService: DependencyKey {
     static var liveValue = Self { requestModel, token  in
         do {
             // 네트워크 요청
-            let data: SignUpEntity = try await baseService.request(
+            let data: SignEntity = try await baseService.request(
                 .signUp(
                     requestModel: requestModel,
                     token: token
@@ -42,7 +42,7 @@ extension SignUpService: DependencyKey {
             try KeychainManager.shared.createUserToken(token)
             
             // 유저 Default 저장
-            saveUser(data: data)
+            saveUser(data: data.toDomain())
             
             return .success
         } catch {
@@ -65,13 +65,8 @@ extension SignUpService: DependencyKey {
         }
     }
     
-    static func saveUser(data: SignUpEntity) {
-        UserDefaultList.user = User(
-            id: data.userID,
-            name: data.nickname,
-            profileImageURL: data.profileImageUrl,
-            platform: data.platform == "apple" ? .apple : .kakao
-        )
+    static func saveUser(data: User) {
+        UserDefaultList.user = data
     }
 }
 

--- a/Baggle/Baggle/Features/Tab/MyPage/MyPageFeature.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/MyPageFeature.swift
@@ -64,7 +64,14 @@ struct MyPageFeature: ReducerProtocol {
                 return .none
                 
             case .logoutButtonTapped:
-                return .none
+                // 임시 로그아웃 연결
+                do {
+                    try KeychainManager.shared.deleteUserToken()
+                } catch let error {
+                    print("Keychain error - \(error)")
+                }
+                UserDefaultList.user = nil
+                return .run { send in await send(.delegate(.moveToLogin)) }
                 
             case .withdrawButtonTapped:
                 state.isLoading = true


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
close #146 

## 내용
<!--
로직 설명  
--> 
1. APIError에 notFound 타입(404) 추가했습니다.
2. 기존에 SignUpEntity를 회원가입과 로그인에서 공통으로 사용할 수 있도록 SignEntity로 수정했습니다.
3. 최초 로그인시 LoginServiceState에 따라 홈으로 이동 / 회원가입으로 이동하도록 로직 수정했습니다.

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 
![ezgif com-resize (37)](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/e1aa826d-ff2c-41ba-8909-b93462bdaf65)



## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
