### PR TITLE
마이페이지 View 초기 구성

### DIFF
--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		144733442A78C8D00090D15E /* BaggleTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144733432A78C8D00090D15E /* BaggleTextEditor.swift */; };
 		1461B6002A7BA3F000A15706 /* BubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1461B5FF2A7BA3F000A15706 /* BubbleView.swift */; };
 		1461B6022A7BA8C500A15706 /* RoundedTriangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1461B6012A7BA8C500A15706 /* RoundedTriangle.swift */; };
+		1462373E2A87760E00FBE121 /* SettingListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1462373D2A87760E00FBE121 /* SettingListRow.swift */; };
+		146237432A877C1600FBE121 /* SettingListHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146237422A877C1600FBE121 /* SettingListHeader.swift */; };
 		146C51D52A79139900FF3142 /* BaggleDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146C51D42A79139900FF3142 /* BaggleDateTests.swift */; };
 		146C51DD2A7913B400FF3142 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 146C51DC2A7913B400FF3142 /* FirebaseMessaging */; };
 		146C51E02A79143A00FF3142 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146C51DF2A79143A00FF3142 /* Date+.swift */; };
@@ -206,6 +208,8 @@
 		144733432A78C8D00090D15E /* BaggleTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggleTextEditor.swift; sourceTree = "<group>"; };
 		1461B5FF2A7BA3F000A15706 /* BubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleView.swift; sourceTree = "<group>"; };
 		1461B6012A7BA8C500A15706 /* RoundedTriangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedTriangle.swift; sourceTree = "<group>"; };
+		1462373D2A87760E00FBE121 /* SettingListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingListRow.swift; sourceTree = "<group>"; };
+		146237422A877C1600FBE121 /* SettingListHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingListHeader.swift; sourceTree = "<group>"; };
 		146C51D22A79139900FF3142 /* BaggleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BaggleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		146C51D42A79139900FF3142 /* BaggleDateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggleDateTests.swift; sourceTree = "<group>"; };
 		146C51DF2A79143A00FF3142 /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
@@ -561,6 +565,7 @@
 		1432BE6E2A682FCE0098AAA9 /* MyPage */ = {
 			isa = PBXGroup;
 			children = (
+				1462373F2A8776EF00FBE121 /* Setting */,
 				1432BE6F2A682FDB0098AAA9 /* MyPageView.swift */,
 				14E506572A6BC576008D5778 /* MyPageFeature.swift */,
 			);
@@ -649,6 +654,15 @@
 				1461B5FF2A7BA3F000A15706 /* BubbleView.swift */,
 			);
 			path = Bubble;
+			sourceTree = "<group>";
+		};
+		1462373F2A8776EF00FBE121 /* Setting */ = {
+			isa = PBXGroup;
+			children = (
+				1462373D2A87760E00FBE121 /* SettingListRow.swift */,
+				146237422A877C1600FBE121 /* SettingListHeader.swift */,
+			);
+			path = Setting;
 			sourceTree = "<group>";
 		};
 		146C51D32A79139900FF3142 /* BaggleTests */ = {
@@ -1341,6 +1355,7 @@
 				1410AD262A84BEB6008793FB /* Memeber.swift in Sources */,
 				14E506542A6B8ED3008D5778 /* SignUpSuccessView.swift in Sources */,
 				2B84696B2A6E7AE200D75D32 /* BaggleTextField.swift in Sources */,
+				146237432A877C1600FBE121 /* SettingListHeader.swift in Sources */,
 				149C0F482A77850A00B95A36 /* CreateSuccessView.swift in Sources */,
 				2BA345A52A6EB02F00B7E2BD /* BaggleTag.swift in Sources */,
 				2BDEAC7C2A863DCB00D698E6 /* JoinMeeting.swift in Sources */,
@@ -1377,6 +1392,7 @@
 				2B5BE6B22A77A40900F25474 /* MeetingDetailService.swift in Sources */,
 				2BABCB2C2A76D1AF00AFECA3 /* MeetingDetailFeature.swift in Sources */,
 				2B39F21C2A738BB100E034A3 /* SendInvitation.swift in Sources */,
+				1462373E2A87760E00FBE121 /* SettingListRow.swift in Sources */,
 				2B84696A2A6E7AE200D75D32 /* BaggleAlert.swift in Sources */,
 				14E577AC2A80973B00119FB3 /* EmergencyView.swift in Sources */,
 				2BCACB7F2A742C9000892D45 /* BaggleTextFeature.swift in Sources */,

--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		1462373E2A87760E00FBE121 /* SettingListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1462373D2A87760E00FBE121 /* SettingListRow.swift */; };
 		146237432A877C1600FBE121 /* SettingListHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146237422A877C1600FBE121 /* SettingListHeader.swift */; };
 		146237462A877CFB00FBE121 /* PlatformLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146237452A877CFB00FBE121 /* PlatformLogoView.swift */; };
+		146237482A87803F00FBE121 /* SafariWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146237472A87803F00FBE121 /* SafariWebView.swift */; };
 		146C51D52A79139900FF3142 /* BaggleDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146C51D42A79139900FF3142 /* BaggleDateTests.swift */; };
 		146C51DD2A7913B400FF3142 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 146C51DC2A7913B400FF3142 /* FirebaseMessaging */; };
 		146C51E02A79143A00FF3142 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146C51DF2A79143A00FF3142 /* Date+.swift */; };
@@ -212,6 +213,7 @@
 		1462373D2A87760E00FBE121 /* SettingListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingListRow.swift; sourceTree = "<group>"; };
 		146237422A877C1600FBE121 /* SettingListHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingListHeader.swift; sourceTree = "<group>"; };
 		146237452A877CFB00FBE121 /* PlatformLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformLogoView.swift; sourceTree = "<group>"; };
+		146237472A87803F00FBE121 /* SafariWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariWebView.swift; sourceTree = "<group>"; };
 		146C51D22A79139900FF3142 /* BaggleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BaggleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		146C51D42A79139900FF3142 /* BaggleDateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggleDateTests.swift; sourceTree = "<group>"; };
 		146C51DF2A79143A00FF3142 /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
@@ -1112,6 +1114,7 @@
 				2B30E33B2A6F9DD500949151 /* UserDefaultWrapper.swift */,
 				2B30E33D2A6F9DF000949151 /* UserDefaultKeyList.swift */,
 				2BDEAC752A86024E00D698E6 /* KeychainManager.swift */,
+				146237472A87803F00FBE121 /* SafariWebView.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -1436,6 +1439,7 @@
 				2BF268232A77861300F32ADF /* HomeService.swift in Sources */,
 				14CF68EC2A847BEF00E457DF /* User.swift in Sources */,
 				140E88112A64B626005119F8 /* BaggleApp.swift in Sources */,
+				146237482A87803F00FBE121 /* SafariWebView.swift in Sources */,
 				14F7B0962A7BABC30068B1E4 /* BubbleType.swift in Sources */,
 				146C51EE2A79429400FF3142 /* SelectDateFeature.swift in Sources */,
 				2BF6EC1B2A7FF5DC006CA492 /* NavigationBar.swift in Sources */,

--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		1461B6022A7BA8C500A15706 /* RoundedTriangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1461B6012A7BA8C500A15706 /* RoundedTriangle.swift */; };
 		1462373E2A87760E00FBE121 /* SettingListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1462373D2A87760E00FBE121 /* SettingListRow.swift */; };
 		146237432A877C1600FBE121 /* SettingListHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146237422A877C1600FBE121 /* SettingListHeader.swift */; };
+		146237462A877CFB00FBE121 /* PlatformLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146237452A877CFB00FBE121 /* PlatformLogoView.swift */; };
 		146C51D52A79139900FF3142 /* BaggleDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146C51D42A79139900FF3142 /* BaggleDateTests.swift */; };
 		146C51DD2A7913B400FF3142 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 146C51DC2A7913B400FF3142 /* FirebaseMessaging */; };
 		146C51E02A79143A00FF3142 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146C51DF2A79143A00FF3142 /* Date+.swift */; };
@@ -210,6 +211,7 @@
 		1461B6012A7BA8C500A15706 /* RoundedTriangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedTriangle.swift; sourceTree = "<group>"; };
 		1462373D2A87760E00FBE121 /* SettingListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingListRow.swift; sourceTree = "<group>"; };
 		146237422A877C1600FBE121 /* SettingListHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingListHeader.swift; sourceTree = "<group>"; };
+		146237452A877CFB00FBE121 /* PlatformLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformLogoView.swift; sourceTree = "<group>"; };
 		146C51D22A79139900FF3142 /* BaggleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BaggleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		146C51D42A79139900FF3142 /* BaggleDateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggleDateTests.swift; sourceTree = "<group>"; };
 		146C51DF2A79143A00FF3142 /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
@@ -565,6 +567,7 @@
 		1432BE6E2A682FCE0098AAA9 /* MyPage */ = {
 			isa = PBXGroup;
 			children = (
+				146237442A877CEA00FBE121 /* Profile */,
 				1462373F2A8776EF00FBE121 /* Setting */,
 				1432BE6F2A682FDB0098AAA9 /* MyPageView.swift */,
 				14E506572A6BC576008D5778 /* MyPageFeature.swift */,
@@ -663,6 +666,14 @@
 				146237422A877C1600FBE121 /* SettingListHeader.swift */,
 			);
 			path = Setting;
+			sourceTree = "<group>";
+		};
+		146237442A877CEA00FBE121 /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+				146237452A877CFB00FBE121 /* PlatformLogoView.swift */,
+			);
+			path = Profile;
 			sourceTree = "<group>";
 		};
 		146C51D32A79139900FF3142 /* BaggleTests */ = {
@@ -1313,6 +1324,7 @@
 				2B7B4D772A84B41000283248 /* SignUpEntity.swift in Sources */,
 				2BB6BA902A82039300F04188 /* MeetingDetailButtonType.swift in Sources */,
 				1461B6002A7BA3F000A15706 /* BubbleView.swift in Sources */,
+				146237462A877CFB00FBE121 /* PlatformLogoView.swift in Sources */,
 				2B84696D2A6E7AE200D75D32 /* ShadeView.swift in Sources */,
 				2BABCB282A76D08400AFECA3 /* PostObserverAction.swift in Sources */,
 				1432BE6D2A682FCB0098AAA9 /* HomeView.swift in Sources */,

--- a/Baggle/Baggle/Core/Common/Foundation/SafariWebView.swift
+++ b/Baggle/Baggle/Core/Common/Foundation/SafariWebView.swift
@@ -1,0 +1,21 @@
+//
+//  SafariWebView.swift
+//  Baggle
+//
+//  Created by youtak on 2023/08/12.
+//
+
+import SafariServices
+import SwiftUI
+
+struct SafariWebView: UIViewControllerRepresentable {
+    let url: URL
+    
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        return SFSafariViewController(url: url)
+    }
+    
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {
+        
+    }
+}

--- a/Baggle/Baggle/Core/Models/User/User.swift
+++ b/Baggle/Baggle/Core/Models/User/User.swift
@@ -14,6 +14,17 @@ public struct User: Codable, Equatable {
     let platform: LoginPlatform
 }
 
+extension User {
+    public static func error() -> User {
+        User(
+            id: -1,
+            name: "에러",
+            profileImageURL: "",
+            platform: .apple
+        )
+    }
+}
+
 #if DEBUG
 extension User {
     static func mockUp() -> User {

--- a/Baggle/Baggle/Features/Tab/MyPage/MyPageFeature.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/MyPageFeature.swift
@@ -10,6 +10,7 @@ import ComposableArchitecture
 struct MyPageFeature: ReducerProtocol {
 
     struct State: Equatable {
+        var user = UserDefaultList.user ?? User(id: -1, name: "에러", profileImageURL: "", platform: .apple)
     }
 
     enum Action: Equatable {

--- a/Baggle/Baggle/Features/Tab/MyPage/MyPageFeature.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/MyPageFeature.swift
@@ -5,21 +5,31 @@
 //  Created by youtak on 2023/07/22.
 //
 
+import SwiftUI
+
 import ComposableArchitecture
 
 struct MyPageFeature: ReducerProtocol {
 
     struct State: Equatable {
-        var user = UserDefaultList.user ?? User(id: -1, name: "에러", profileImageURL: "", platform: .apple)
+        var user = UserDefaultList.user ?? User.error()
+        
+        var presentSafariView: Bool = false
+        var safariURL: String = ""
     }
 
     enum Action: Equatable {
         case logoutMyPage
+
+        case notificationSettingButtonTapped
+        case privacyPolicyButtonTapped
+        case termsOfServiceButtonTapped
+        case presentSafariView
     }
 
     var body: some ReducerProtocolOf<Self> {
 
-        Reduce { _, action in
+        Reduce { state, action in
             switch action {
 
             case .logoutMyPage:
@@ -29,6 +39,26 @@ struct MyPageFeature: ReducerProtocol {
                     print("Keychain error - \(error)")
                 }
                 UserDefaultList.user = nil
+                return .none
+                
+            case .notificationSettingButtonTapped:
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+                return .none
+                
+            case .privacyPolicyButtonTapped: 
+                state.safariURL = "https://www.dnd.ac/"
+                state.presentSafariView = true
+                return .none
+                
+            case .termsOfServiceButtonTapped:
+                state.safariURL = "https://www.naver.com/"
+                state.presentSafariView = true
+                return .none
+                
+            case .presentSafariView:
+                state.presentSafariView = false
                 return .none
             }
         }

--- a/Baggle/Baggle/Features/Tab/MyPage/MyPageFeature.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/MyPageFeature.swift
@@ -24,6 +24,9 @@ struct MyPageFeature: ReducerProtocol {
         case notificationSettingButtonTapped
         case privacyPolicyButtonTapped
         case termsOfServiceButtonTapped
+        case logoutButtonTapped
+        case withdrawButtonTapped
+        
         case presentSafariView
     }
 
@@ -55,6 +58,12 @@ struct MyPageFeature: ReducerProtocol {
             case .termsOfServiceButtonTapped:
                 state.safariURL = "https://www.naver.com/"
                 state.presentSafariView = true
+                return .none
+                
+            case .logoutButtonTapped:
+                return .none
+
+            case .withdrawButtonTapped:
                 return .none
                 
             case .presentSafariView:

--- a/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
@@ -79,8 +79,11 @@ struct MyPageView: View {
                 // MARK: - 계정
                 
                 Section {
+                    SettingListRow(text: "로그아웃", isArrow: false) {
+                        viewStore.send(.logoutButtonTapped)
+                    }
                     SettingListRow(text: "계정 탈퇴", isArrow: false) {
-                        print("서비스 이용약솬")
+                        viewStore.send(.withdrawButtonTapped)
                     }
                 } header: {
                     SettingListHeader(text: "계정")

--- a/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
@@ -14,13 +14,14 @@ struct MyPageView: View {
     
     let store: StoreOf<MyPageFeature>
     
-    @State var textfield: String = ""
-    
     var body: some View {
         
         WithViewStore(self.store, observe: { $0 }) { viewStore in
             
             List {
+                
+                // MARK: - 프로필
+                
                 Section {
                     HStack {
                         Spacer()
@@ -41,7 +42,7 @@ struct MyPageView: View {
                                 Text(viewStore.user.name)
                                     .font(.Baggle.subTitle)
                                     .foregroundColor(.gray11)
-   
+                                
                                 PlatformLogoView(platform: viewStore.user.platform)
                             }
                         }
@@ -51,51 +52,65 @@ struct MyPageView: View {
                         
                         Spacer()
                     }
-                }
-                .listRowSeparator(.hidden)
-                
-                
-                
-                Section {
-                    SettingListRow(text: "알림 설정") {
-                        print("알림 설정")
-                    }
+                    .listRowSeparator(.hidden)
                     
-                    SettingListRow(text: "개인정보 처리방침") {
-                        print("개인정보 처리방침")
-                    }
+                    // MARK: - 일반 설정
                     
-                    SettingListRow(text: "서비스 이용약관") {
-                        print("서비스 이용약솬")
+                    Section {
+                        SettingListRow(text: "알림 설정") {
+                            viewStore.send(.notificationSettingButtonTapped)
+                        }
+                        
+                        SettingListRow(text: "개인정보 처리방침") {
+                            viewStore.send(.privacyPolicyButtonTapped)
+                        }
+                        
+                        SettingListRow(text: "서비스 이용약관") {
+                            viewStore.send(.termsOfServiceButtonTapped)
+                        }
+                    } header: {
+                        SettingListHeader(text: "일반 설정")
                     }
-                } header: {
-                    SettingListHeader(text: "일반 설정")
-                }
-                .listRowSeparator(.hidden)
-                .listRowInsets(EdgeInsets())
-                
-                Section {
-                    SettingListRow(text: "계정 탈퇴", isArrow: false) {
-                        print("서비스 이용약솬")
+                    .listRowSeparator(.hidden)
+                    .listSectionSeparator(.hidden)
+                    .listRowInsets(EdgeInsets())
+                    
+                    // MARK: - 계정
+                    
+                    Section {
+                        SettingListRow(text: "계정 탈퇴", isArrow: false) {
+                            print("서비스 이용약솬")
+                        }
+                    } header: {
+                        SettingListHeader(text: "계정")
                     }
-                } header: {
-                    SettingListHeader(text: "계정")
+                    .listRowSeparator(.hidden)
+                    .listSectionSeparator(.hidden)
+                    .listRowInsets(EdgeInsets())
                 }
-                .listRowSeparator(.hidden)
                 .listRowInsets(EdgeInsets())
+                .listStyle(.plain)
+                .fullScreenCover(
+                    isPresented: viewStore.binding(
+                        get: \.presentSafariView,
+                        send: { _ in MyPageFeature.Action.presentSafariView }
+                    )
+                ) {
+                    if let url = URL(string: viewStore.state.safariURL) {
+                        SafariWebView(url: url)
+                    }
+                }
             }
-            .listStyle(.plain)
         }
     }
-}
-
-struct MyPageView_Previews: PreviewProvider {
-    static var previews: some View {
-        MyPageView(
-            store: Store(
-                initialState: MyPageFeature.State(),
-                reducer: MyPageFeature()
+    
+    struct MyPageView_Previews: PreviewProvider {
+        static var previews: some View {
+            MyPageView(
+                store: Store(
+                    initialState: MyPageFeature.State(),
+                    reducer: MyPageFeature()
+                )
             )
-        )
+        }
     }
-}

--- a/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
@@ -8,37 +8,89 @@
 import SwiftUI
 
 import ComposableArchitecture
+import Kingfisher
 
 struct MyPageView: View {
-
+    
     let store: StoreOf<MyPageFeature>
-
+    
     @State var textfield: String = ""
-
+    
     var body: some View {
-
+        
         WithViewStore(self.store, observe: { $0 }) { viewStore in
-
-            VStack {
-                Text("마이페이지입니다. 마이페이지입니다. 마이페이지입니다.")
-
-                Button {
-                    viewStore.send(.logoutMyPage)
-                } label: {
+            
+            List {
+                Section {
                     HStack {
-
                         Spacer()
-
-                        Text("로그아웃")
-                            .font(.title)
-                            .padding()
-
+                        
+                        VStack(spacing: 16) {
+                            KFImage(URL(string: ""))
+                                .placeholder({ _ in
+                                    Image.Profile.profilDefault
+                                        .resizable()
+                                })
+                                .resizable()
+                                .aspectRatio(1.0, contentMode: .fill)
+                                .frame(width: 100, height: 100)
+                                .cornerRadius(50)
+                                .clipped()
+                            
+                            HStack(alignment: .top, spacing: 6) {
+                                Text("바글이")
+                                    .font(.Baggle.subTitle)
+                                    .foregroundColor(.gray11)
+                                
+                                Image.Icon.kakao
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 14)
+                                    .padding(4)
+                                    .background(.yellow)
+                                    .cornerRadius(30)
+                            }
+                        }
+                        .padding(.top, 32)
+                        .padding(.bottom, 24)
+                        .padding(.horizontal, 20)
+                        
                         Spacer()
                     }
                 }
-                .buttonStyle(.borderedProminent)
-                .padding()
+                .listRowSeparator(.hidden)
+                
+                
+                
+                Section {
+                    SettingListRow(text: "알림 설정") {
+                        print("알림 설정")
+                    }
+                    
+                    SettingListRow(text: "개인정보 처리방침") {
+                        print("개인정보 처리방침")
+                    }
+                    
+                    SettingListRow(text: "서비스 이용약관") {
+                        print("서비스 이용약솬")
+                    }
+                } header: {
+                    SettingListHeader(text: "일반 설정")
+                }
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets())
+                
+                Section {
+                    SettingListRow(text: "계정 탈퇴", isArrow: false) {
+                        print("서비스 이용약솬")
+                    }
+                } header: {
+                    SettingListHeader(text: "계정")
+                }
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets())
             }
+            .listStyle(.plain)
         }
     }
 }

--- a/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
@@ -52,65 +52,66 @@ struct MyPageView: View {
                         
                         Spacer()
                     }
-                    .listRowSeparator(.hidden)
-                    
-                    // MARK: - 일반 설정
-                    
-                    Section {
-                        SettingListRow(text: "알림 설정") {
-                            viewStore.send(.notificationSettingButtonTapped)
-                        }
-                        
-                        SettingListRow(text: "개인정보 처리방침") {
-                            viewStore.send(.privacyPolicyButtonTapped)
-                        }
-                        
-                        SettingListRow(text: "서비스 이용약관") {
-                            viewStore.send(.termsOfServiceButtonTapped)
-                        }
-                    } header: {
-                        SettingListHeader(text: "일반 설정")
-                    }
-                    .listRowSeparator(.hidden)
-                    .listSectionSeparator(.hidden)
-                    .listRowInsets(EdgeInsets())
-                    
-                    // MARK: - 계정
-                    
-                    Section {
-                        SettingListRow(text: "계정 탈퇴", isArrow: false) {
-                            print("서비스 이용약솬")
-                        }
-                    } header: {
-                        SettingListHeader(text: "계정")
-                    }
-                    .listRowSeparator(.hidden)
-                    .listSectionSeparator(.hidden)
-                    .listRowInsets(EdgeInsets())
                 }
-                .listRowInsets(EdgeInsets())
-                .listStyle(.plain)
-                .fullScreenCover(
-                    isPresented: viewStore.binding(
-                        get: \.presentSafariView,
-                        send: { _ in MyPageFeature.Action.presentSafariView }
-                    )
-                ) {
-                    if let url = URL(string: viewStore.state.safariURL) {
-                        SafariWebView(url: url)
+                .listRowSeparator(.hidden)
+                
+                // MARK: - 일반 설정
+                
+                Section {
+                    SettingListRow(text: "알림 설정") {
+                        viewStore.send(.notificationSettingButtonTapped)
                     }
+                    
+                    SettingListRow(text: "개인정보 처리방침") {
+                        viewStore.send(.privacyPolicyButtonTapped)
+                    }
+                    
+                    SettingListRow(text: "서비스 이용약관") {
+                        viewStore.send(.termsOfServiceButtonTapped)
+                    }
+                } header: {
+                    SettingListHeader(text: "일반 설정")
+                }
+                .listRowSeparator(.hidden)
+                .listSectionSeparator(.hidden)
+                .listRowInsets(EdgeInsets())
+                
+                // MARK: - 계정
+                
+                Section {
+                    SettingListRow(text: "계정 탈퇴", isArrow: false) {
+                        print("서비스 이용약솬")
+                    }
+                } header: {
+                    SettingListHeader(text: "계정")
+                }
+                .listRowSeparator(.hidden)
+                .listSectionSeparator(.hidden)
+                .listRowInsets(EdgeInsets())
+            }
+            .listRowInsets(EdgeInsets())
+            .listStyle(.plain)
+            .fullScreenCover(
+                isPresented: viewStore.binding(
+                    get: \.presentSafariView,
+                    send: { _ in MyPageFeature.Action.presentSafariView }
+                )
+            ) {
+                if let url = URL(string: viewStore.state.safariURL) {
+                    SafariWebView(url: url)
                 }
             }
         }
     }
-    
-    struct MyPageView_Previews: PreviewProvider {
-        static var previews: some View {
-            MyPageView(
-                store: Store(
-                    initialState: MyPageFeature.State(),
-                    reducer: MyPageFeature()
-                )
+}
+
+struct MyPageView_Previews: PreviewProvider {
+    static var previews: some View {
+        MyPageView(
+            store: Store(
+                initialState: MyPageFeature.State(),
+                reducer: MyPageFeature()
             )
-        }
+        )
     }
+}

--- a/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
@@ -42,13 +42,6 @@ struct MyPageView: View {
                                     .font(.Baggle.subTitle)
                                     .foregroundColor(.gray11)
                                 
-                                Image.Icon.kakao
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 14)
-                                    .padding(4)
-                                    .background(.yellow)
-                                    .cornerRadius(30)
                             }
                         }
                         .padding(.top, 32)

--- a/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
@@ -26,7 +26,7 @@ struct MyPageView: View {
                         Spacer()
                         
                         VStack(spacing: 16) {
-                            KFImage(URL(string: ""))
+                            KFImage(URL(string: viewStore.user.profileImageURL ?? ""))
                                 .placeholder({ _ in
                                     Image.Profile.profilDefault
                                         .resizable()
@@ -38,10 +38,11 @@ struct MyPageView: View {
                                 .clipped()
                             
                             HStack(alignment: .top, spacing: 6) {
-                                Text("바글이")
+                                Text(viewStore.user.name)
                                     .font(.Baggle.subTitle)
                                     .foregroundColor(.gray11)
-                                
+   
+                                PlatformLogoView(platform: viewStore.user.platform)
                             }
                         }
                         .padding(.top, 32)

--- a/Baggle/Baggle/Features/Tab/MyPage/Profile/PlatformLogoView.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/Profile/PlatformLogoView.swift
@@ -1,0 +1,41 @@
+//
+//  PlatformLogoView.swift
+//  Baggle
+//
+//  Created by youtak on 2023/08/12.
+//
+
+import SwiftUI
+
+struct PlatformLogoView: View {
+    
+    let platform: LoginPlatform
+    
+    var body: some View {
+        switch self .platform {
+        case .apple:
+            Image(systemName: "apple.logo")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 14, height: 14)
+                .padding(4)
+                .foregroundColor(.white)
+                .background(.black)
+                .cornerRadius(30)
+        case .kakao:
+            Image.Icon.kakao
+                .resizable()
+                .scaledToFit()
+                .frame(width: 14, height: 14)
+                .padding(4)
+                .background(.yellow)
+                .cornerRadius(30)
+        }
+    }
+}
+
+struct PlatformLogoView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlatformLogoView(platform: .apple)
+    }
+}

--- a/Baggle/Baggle/Features/Tab/MyPage/Setting/SettingListHeader.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/Setting/SettingListHeader.swift
@@ -1,0 +1,31 @@
+//
+//  SettingListHeader.swift
+//  Baggle
+//
+//  Created by youtak on 2023/08/12.
+//
+
+import SwiftUI
+
+struct SettingListHeader: View {
+    
+    let text: String
+    
+    var body: some View {
+        
+        HStack {
+            Text(text)
+                .font(.Baggle.description)
+                .foregroundColor(.gray6)
+            
+            Spacer()
+        }
+        .padding(20)
+    }
+}
+
+struct SettingListHeader_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingListHeader(text: "Header")
+    }
+}

--- a/Baggle/Baggle/Features/Tab/MyPage/Setting/SettingListRow.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/Setting/SettingListRow.swift
@@ -30,10 +30,9 @@ struct SettingListRow: View {
                 
                 Spacer()
                 
-                if isArrow {
-                    Image.Icon.next
-                        .padding(10)
-                }
+                Image.Icon.next
+                    .padding(10)
+                    .opacity(isArrow ? 1 : 0)
             }
             .padding(.vertical, 10)
             .padding(.leading, 20)
@@ -44,7 +43,7 @@ struct SettingListRow: View {
 
 struct SettingListRow_Previews: PreviewProvider {
     static var previews: some View {
-        SettingListRow(text: "알림 설정", isArrow: true) {
+        SettingListRow(text: "알림 설정", isArrow: false) {
             print("hello")
         }
     }

--- a/Baggle/Baggle/Features/Tab/MyPage/Setting/SettingListRow.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/Setting/SettingListRow.swift
@@ -20,22 +20,24 @@ struct SettingListRow: View {
     }
     
     var body: some View {
-        HStack {
-            Text(text)
-            
-            Spacer()
-            
-            if isArrow {
-                Image.Icon.next
-                    .padding(10)
-            }
-        }
-        .padding(.vertical, 10)
-        .padding(.leading, 20)
-        .padding(.trailing, 10)
-        .touchSpacer()
-        .onTapGesture {
+        Button {
             action()
+        } label: {
+            HStack {
+                Text(text)
+                    .foregroundColor(.gray11)
+                    .font(.Baggle.button)
+                
+                Spacer()
+                
+                if isArrow {
+                    Image.Icon.next
+                        .padding(10)
+                }
+            }
+            .padding(.vertical, 10)
+            .padding(.leading, 20)
+            .padding(.trailing, 10)
         }
     }
 }

--- a/Baggle/Baggle/Features/Tab/MyPage/Setting/SettingListRow.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/Setting/SettingListRow.swift
@@ -1,0 +1,49 @@
+//
+//  SettingListRow.swift
+//  Baggle
+//
+//  Created by youtak on 2023/08/12.
+//
+
+import SwiftUI
+
+struct SettingListRow: View {
+    
+    let text: String
+    let isArrow: Bool
+    let action: () -> Void
+    
+    init(text: String, isArrow: Bool = true, action: @escaping () -> Void) {
+        self.text = text
+        self.isArrow = isArrow
+        self.action = action
+    }
+    
+    var body: some View {
+        HStack {
+            Text(text)
+            
+            Spacer()
+            
+            if isArrow {
+                Image.Icon.next
+                    .padding(10)
+            }
+        }
+        .padding(.vertical, 10)
+        .padding(.leading, 20)
+        .padding(.trailing, 10)
+        .touchSpacer()
+        .onTapGesture {
+            action()
+        }
+    }
+}
+
+struct SettingListRow_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingListRow(text: "알림 설정", isArrow: true) {
+            print("hello")
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #149 

## 내용
<!--
로직 설명  
--> 
- 디자인에 따라 마이페이지를 구현했습니다. 프로필 수정은 후순위라 따로 구현하지 않았습니다.
- 프로필에서 사용할 로고를 위해 `Platform Logo View`를 만들었습니다.
```swift
PlatformLogoView(platform: .apple) // 혹은 .kakao
```
- 알림 설정 클릭시 설정 - 바글로 이동합니다.
- 개인 정보처리방침, 서비스 이용약관 클릭시 각각 dnd 홈페이지랑 네이버 홈페이지로 이동합니다. 이전에 Safari View Controller 안 사용해서 reject 먹은 적이 있어 `UIViewControllerRepresentable`를 채택하는 `SafariWebView`를 구현했습니다.


### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

- 알림 설정 - 설정 창으로 이동
 
![Simulator Screen Recording - iPhone 14 Pro - 2023-08-12 at 19 40 10](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/86f4e30c-6616-4c44-b1e1-55c01c29e145)

- Safari Web View

![Simulator Screen Recording - iPhone 14 Pro - 2023-08-12 at 19 40 19](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/50274a6c-b4de-4463-9aca-62cf55306c7e)

- (+추가) 로그아웃 버튼 추가했습니다.

![스크린샷 2023-08-12 오후 7 52 19](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/16441adc-bab9-4039-949f-9960893b50f5)


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- 디자인대로 할라했는데 이미지에 보이는 것처럼 Section 사이의 spacing을 못 없앴네요... 정식 방법은 iOS 17부터 지원되서 다른 방법을 찾아보겠습니다. (`UITableView.appearance().sectionFooterHeight = 0` 했는데도 안 됐어요)

<img width = 250 src = "https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/60bef93b-e63d-4af9-bea5-8f688139169b" />

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
