### PR TITLE
Feat #157 - Const, URL 파일 추가, 기존 url 수정

### DIFF
--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -153,6 +153,8 @@
 		2BABCB2C2A76D1AF00AFECA3 /* MeetingDetailFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BABCB2A2A76D1AF00AFECA3 /* MeetingDetailFeature.swift */; };
 		2BABCB2D2A76D1AF00AFECA3 /* MeetingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BABCB2B2A76D1AF00AFECA3 /* MeetingDetailView.swift */; };
 		2BB6BA902A82039300F04188 /* MeetingDetailButtonType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB6BA8F2A82039300F04188 /* MeetingDetailButtonType.swift */; };
+		2BB7FBC52A89289E0003B75C /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB7FBC42A89289E0003B75C /* URL.swift */; };
+		2BB7FBC72A892A520003B75C /* Const.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB7FBC62A892A520003B75C /* Const.swift */; };
 		2BC5AD2F2A84938600B73241 /* UserAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BC5AD2E2A84938600B73241 /* UserAPI.swift */; };
 		2BC5AD312A84983C00B73241 /* SignUpRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BC5AD302A84983C00B73241 /* SignUpRequestModel.swift */; };
 		2BCACB7F2A742C9000892D45 /* BaggleTextFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BCACB7E2A742C9000892D45 /* BaggleTextFeature.swift */; };
@@ -321,6 +323,8 @@
 		2BABCB2A2A76D1AF00AFECA3 /* MeetingDetailFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeetingDetailFeature.swift; sourceTree = "<group>"; };
 		2BABCB2B2A76D1AF00AFECA3 /* MeetingDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeetingDetailView.swift; sourceTree = "<group>"; };
 		2BB6BA8F2A82039300F04188 /* MeetingDetailButtonType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDetailButtonType.swift; sourceTree = "<group>"; };
+		2BB7FBC42A89289E0003B75C /* URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
+		2BB7FBC62A892A520003B75C /* Const.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Const.swift; sourceTree = "<group>"; };
 		2BC5AD2E2A84938600B73241 /* UserAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAPI.swift; sourceTree = "<group>"; };
 		2BC5AD302A84983C00B73241 /* SignUpRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRequestModel.swift; sourceTree = "<group>"; };
 		2BCACB7E2A742C9000892D45 /* BaggleTextFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggleTextFeature.swift; sourceTree = "<group>"; };
@@ -459,6 +463,7 @@
 		14134D3B2A64C532004A6AC4 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				2BB7FBC32A8928490003B75C /* Const */,
 				2B7B4D6C2A84A1F200283248 /* Network */,
 				2BABCB202A76CFD100AFECA3 /* Foundation */,
 				14F2D7AF2A728A14000ED0EE /* Extensions */,
@@ -1154,6 +1159,15 @@
 			path = MeetingDetail;
 			sourceTree = "<group>";
 		};
+		2BB7FBC32A8928490003B75C /* Const */ = {
+			isa = PBXGroup;
+			children = (
+				2BB7FBC42A89289E0003B75C /* URL.swift */,
+				2BB7FBC62A892A520003B75C /* Const.swift */,
+			);
+			path = Const;
+			sourceTree = "<group>";
+		};
 		2BDEAC772A863D1500D698E6 /* JoinMeeting */ = {
 			isa = PBXGroup;
 			children = (
@@ -1459,6 +1473,7 @@
 				2B9F27172A813AEA009ED284 /* ProfileBadgeView.swift in Sources */,
 				14E4C4B72A6E43CA008643D9 /* CreateTitleFeature.swift in Sources */,
 				2B86CBC02A70F00900800B02 /* HomeFeature.swift in Sources */,
+				2BB7FBC52A89289E0003B75C /* URL.swift in Sources */,
 				2B604DDA2A7F60E7000E2DE2 /* CircleProfileView.swift in Sources */,
 				1493A9122A7DE4AB00A2D7CC /* SmallTimerView.swift in Sources */,
 				14F055AC2A8220C50041B004 /* BadgeView.swift in Sources */,
@@ -1477,6 +1492,7 @@
 				2BABCB222A76CFDC00AFECA3 /* Notification+Name.swift in Sources */,
 				14E0836F2A836C1D0001CB21 /* MeetingDetailMemberEntity.swift in Sources */,
 				2B7B4D742A84A5EC00283248 /* ProfileImageModel.swift in Sources */,
+				2BB7FBC72A892A520003B75C /* Const.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Baggle/Baggle/Core/Common/Const/Const.swift
+++ b/Baggle/Baggle/Core/Common/Const/Const.swift
@@ -1,0 +1,10 @@
+//
+//  Const.swift
+//  Baggle
+//
+//  Created by 양수빈 on 2023/08/14.
+//
+
+import Foundation
+
+struct Const { }

--- a/Baggle/Baggle/Core/Common/Const/URL.swift
+++ b/Baggle/Baggle/Core/Common/Const/URL.swift
@@ -1,0 +1,18 @@
+//
+//  URL.swift
+//  Baggle
+//
+//  Created by 양수빈 on 2023/08/14.
+//
+
+import Foundation
+
+// swiftlint:disable all
+extension Const {
+    struct URL {
+        static let privacyPolicy = "https://www.dnd.ac/"
+        static let termsOfService = "https://www.naver.com/"
+        static let invitationThumbnail = "https://bagglebucket.s3.ap-northeast-2.amazonaws.com/link_participation.png"
+    }
+}
+// swiftlint:enable all

--- a/Baggle/Baggle/Core/Services/SendInvitation.swift
+++ b/Baggle/Baggle/Core/Services/SendInvitation.swift
@@ -48,8 +48,7 @@ public struct SendInvitationEffect: Sendable {
         let appLink = Link(iosExecutionParams: ["name": name, "id": "\(id)"])
         let button = Button(title: "약속 참여하기", link: appLink)
         
-        // swiftlint:disable:next line_length
-        guard let thumbnailUrl = URL(string: "https://bagglebucket.s3.ap-northeast-2.amazonaws.com/link_participation.png") else { return nil }
+        guard let thumbnailUrl = URL(string: Const.URL.invitationThumbnail) else { return nil }
 
         let content = Content(
             title: name,

--- a/Baggle/Baggle/Features/Tab/MyPage/MyPageFeature.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/MyPageFeature.swift
@@ -54,12 +54,12 @@ struct MyPageFeature: ReducerProtocol {
                 return .none
                 
             case .privacyPolicyButtonTapped: 
-                state.safariURL = "https://www.dnd.ac/"
+                state.safariURL = Const.URL.privacyPolicy
                 state.presentSafariView = true
                 return .none
                 
             case .termsOfServiceButtonTapped:
-                state.safariURL = "https://www.naver.com/"
+                state.safariURL = Const.URL.termsOfService
                 state.presentSafariView = true
                 return .none
                 


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
close #157 

## 내용
<!--
로직 설명  
--> 

Const, URL 파일 생성하고, 기존에 사용하던 url을 모아 정리했습니다.
URL만 관리할까 했는데, 이후 추가될 로티까지 같이 상수라는 큰 개념 아래에서 관리하는게 나을까 싶어서 생성했습니다.
아래처럼 정의해서 사용할 수 있을 것 같습니다.
```
extension Const {
    struct Lottie {
        static let splash = "splash_logo"
    }
}

Const.Lottie.splash
```

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- Const로 묶을까요? 그냥 URL로만 정의해서 사용하는게 나을까요?

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
