### PR TITLE
모임 생성 날짜 자동 선택 & 날짜 로직 수정 & 메모 생성에서 날짜 한 번 더 확인

### DIFF
--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		149C0F482A77850A00B95A36 /* CreateSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149C0F472A77850A00B95A36 /* CreateSuccessView.swift */; };
 		14B7A0412A753D4800B8E202 /* SignUpService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B7A0402A753D4800B8E202 /* SignUpService.swift */; };
 		14B7A0452A75409E00B8E202 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B7A0442A75409E00B8E202 /* APIError.swift */; };
+		14C8F9D42A8B3B82001690C5 /* MeetingCreateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C8F9D32A8B3B82001690C5 /* MeetingCreateModel.swift */; };
 		14CF68E92A846EB700E457DF /* TestDateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CF68E82A846EB700E457DF /* TestDateService.swift */; };
 		14CF68EC2A847BEF00E457DF /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CF68EB2A847BEF00E457DF /* User.swift */; };
 		14CF68EE2A847C5C00E457DF /* LoginPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CF68ED2A847C5C00E457DF /* LoginPlatform.swift */; };
@@ -267,6 +268,7 @@
 		149C0F472A77850A00B95A36 /* CreateSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateSuccessView.swift; sourceTree = "<group>"; };
 		14B7A0402A753D4800B8E202 /* SignUpService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpService.swift; sourceTree = "<group>"; };
 		14B7A0442A75409E00B8E202 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
+		14C8F9D32A8B3B82001690C5 /* MeetingCreateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCreateModel.swift; sourceTree = "<group>"; };
 		14CF68E82A846EB700E457DF /* TestDateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDateService.swift; sourceTree = "<group>"; };
 		14CF68EB2A847BEF00E457DF /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		14CF68ED2A847C5C00E457DF /* LoginPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPlatform.swift; sourceTree = "<group>"; };
@@ -507,6 +509,7 @@
 		14134D412A64C561004A6AC4 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				14C8F9D22A8B3B7A001690C5 /* MeetingCreate */,
 				2B7B4D7A2A84D1E100283248 /* Common */,
 				14783EDB2A7E2EE700EF58D5 /* Camera */,
 				14B7A0432A75409400B8E202 /* Error */,
@@ -850,6 +853,14 @@
 				143C7C052A876A20004D83FD /* KeyChainError.swift */,
 			);
 			path = Error;
+			sourceTree = "<group>";
+		};
+		14C8F9D22A8B3B7A001690C5 /* MeetingCreate */ = {
+			isa = PBXGroup;
+			children = (
+				14C8F9D32A8B3B82001690C5 /* MeetingCreateModel.swift */,
+			);
+			path = MeetingCreate;
 			sourceTree = "<group>";
 		};
 		14CF68EA2A847BEB00E457DF /* User */ = {
@@ -1502,6 +1513,7 @@
 				1406858B2A7B676D00824A93 /* CreateDescription.swift in Sources */,
 				14E0836A2A83690D0001CB21 /* EntityContainer.swift in Sources */,
 				2B5BE6B22A77A40900F25474 /* MockUpMeetingDetailService.swift in Sources */,
+				14C8F9D42A8B3B82001690C5 /* MeetingCreateModel.swift in Sources */,
 				2BABCB2C2A76D1AF00AFECA3 /* MeetingDetailFeature.swift in Sources */,
 				2B39F21C2A738BB100E034A3 /* SendInvitation.swift in Sources */,
 				1462373E2A87760E00FBE121 /* SettingListRow.swift in Sources */,

--- a/Baggle/Baggle/Core/Common/Extensions/Date/Date+.swift
+++ b/Baggle/Baggle/Core/Common/Extensions/Date/Date+.swift
@@ -190,8 +190,8 @@ extension Date {
 
     /// 약속 생성 가능 시간 리턴
     /// ex
-    /// 2시 03분 -> 2시 05분
-    /// 2시 05분 -> 2시 10분
+    /// 2시 03분 -> 2시 10분
+    /// 2시 05분 -> 2시 15분
 
     func meetingStartTime() -> Date {
 
@@ -199,7 +199,7 @@ extension Date {
         let twoHoursLater = self.later(hours: 2)
 
         // 5분 이후
-        var twoHoursFiveMinutesLater = twoHoursLater.later(minutes: 5)
+        var twoHoursFiveMinutesLater = twoHoursLater.later(minutes: 10)
 
         // 5분 단위로 만들기
         while twoHoursFiveMinutesLater.minute % 5 != 0 {

--- a/Baggle/Baggle/Core/Services/MeetingCreate/MeetingCreateModel.swift
+++ b/Baggle/Baggle/Core/Services/MeetingCreate/MeetingCreateModel.swift
@@ -10,7 +10,7 @@ import Foundation
 struct MeetingCreateModel: Equatable {
     let title: String?
     let place: String?
-    let meetingTime: Date?
+    let time: Date?
     let memo: String?
 }
 
@@ -19,7 +19,7 @@ extension MeetingCreateModel {
         MeetingCreateModel(
             title: title,
             place: self.place,
-            meetingTime: self.meetingTime,
+            time: self.time,
             memo: self.memo
         )
     }
@@ -28,25 +28,25 @@ extension MeetingCreateModel {
         MeetingCreateModel(
             title: self.title,
             place: place,
-            meetingTime: self.meetingTime,
+            time: self.time,
             memo: self.memo
         )
     }
     
-    func update(meetingTime: Date) -> MeetingCreateModel {
+    func update(time: Date) -> MeetingCreateModel {
         MeetingCreateModel(
             title: self.title,
             place: self.place,
-            meetingTime: meetingTime,
+            time: time,
             memo: self.memo
         )
     }
     
-    func update(memo: String) -> MeetingCreateModel {
+    func update(memo: String?) -> MeetingCreateModel {
         MeetingCreateModel(
             title: self.title,
             place: self.place,
-            meetingTime: self.meetingTime,
+            time: self.time,
             memo: memo
         )
     }

--- a/Baggle/Baggle/Core/Services/MeetingCreate/MeetingCreateModel.swift
+++ b/Baggle/Baggle/Core/Services/MeetingCreate/MeetingCreateModel.swift
@@ -1,0 +1,53 @@
+//
+//  MeetingCreateModel.swift
+//  Baggle
+//
+//  Created by youtak on 2023/08/15.
+//
+
+import Foundation
+
+struct MeetingCreateModel: Equatable {
+    let title: String?
+    let place: String?
+    let meetingTime: Date?
+    let memo: String?
+}
+
+extension MeetingCreateModel {
+    func update(title: String) -> MeetingCreateModel {
+        MeetingCreateModel(
+            title: title,
+            place: self.place,
+            meetingTime: self.meetingTime,
+            memo: self.memo
+        )
+    }
+    
+    func update(place: String) -> MeetingCreateModel {
+        MeetingCreateModel(
+            title: self.title,
+            place: place,
+            meetingTime: self.meetingTime,
+            memo: self.memo
+        )
+    }
+    
+    func update(meetingTime: Date) -> MeetingCreateModel {
+        MeetingCreateModel(
+            title: self.title,
+            place: self.place,
+            meetingTime: meetingTime,
+            memo: self.memo
+        )
+    }
+    
+    func update(memo: String) -> MeetingCreateModel {
+        MeetingCreateModel(
+            title: self.title,
+            place: self.place,
+            meetingTime: self.meetingTime,
+            memo: memo
+        )
+    }
+}

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Date/CreateDateView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Date/CreateDateView.swift
@@ -94,6 +94,9 @@ struct CreateDateView: View {
                 .disabled(viewStore.buttonDisabled)
             }
             .padding()
+            .onAppear {
+                viewStore.send(.onAppear)
+            }
             .sheet(
                 store: self.store.scope(
                     state: \.$selectDateState,

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoFeature.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoFeature.swift
@@ -64,10 +64,13 @@ struct CreateMemoFeature: ReducerProtocol {
                 // Button
 
             case .nextButtonTapped:
-                if let meetingTime = state.meetingCreate.meetingTime, !meetingTime.canMeeting {
+                if let meetingTime = state.meetingCreate.time, !meetingTime.canMeeting {
                     state.isAlertPresented = true
                     return .none
                 }
+                
+                let memo = state.textEditorState.text
+                state.meetingCreate.update(memo: memo)
                 
                 return .run { send in await send(.moveToNextScreen) }
 

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoView.swift
@@ -70,7 +70,7 @@ struct CreateMeetingMemoView_Previews: PreviewProvider {
                     meetingCreate: MeetingCreateModel(
                         title: nil,
                         place: nil,
-                        meetingTime: nil,
+                        time: nil,
                         memo: nil
                     )
                 ),

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Memo/CreateMemoView.swift
@@ -16,33 +16,49 @@ struct CreateMemoView: View {
     var body: some View {
 
         WithViewStore(self.store, observe: { $0 }) { viewStore in
-            VStack(spacing: 0) {
+            
+            ZStack {
+                VStack(spacing: 0) {
 
-                CreateDescription(createStatus: .memo, title: "약속 메모를 남겨보세요.")
+                    CreateDescription(createStatus: .memo, title: "약속 메모를 남겨보세요.")
 
-                BaggleTextEditor(
-                    store: self.store.scope(
-                        state: \.textEditorState,
-                        action: CreateMemoFeature.Action.textEditorAction
-                    ),
-                    title: .title("메모를 입력하세요. (선택)")
-                )
+                    BaggleTextEditor(
+                        store: self.store.scope(
+                            state: \.textEditorState,
+                            action: CreateMemoFeature.Action.textEditorAction
+                        ),
+                        title: .title("메모를 입력하세요. (선택)")
+                    )
 
-                Spacer()
+                    Spacer()
 
-                Button {
-                    viewStore.send(.nextButtonTapped)
-                } label: {
-                    Text("다음")
+                    Button {
+                        viewStore.send(.nextButtonTapped)
+                    } label: {
+                        Text("다음")
+                    }
+                    .buttonStyle(BagglePrimaryStyle())
                 }
-                .buttonStyle(BagglePrimaryStyle())
-            }
-            .touchSpacer()
-            .onTapGesture {
-                hideKeyboard()
+                .padding()
+                .touchSpacer()
+                .onTapGesture {
+                    hideKeyboard()
+                }
+                
+                if viewStore.isAlertPresented {
+                    BaggleAlertOneButton(
+                        isPresented: Binding(
+                            get: { viewStore.isAlertPresented },
+                            set: { _ in viewStore.send(.presentAlert) }
+                        ),
+                        title: "약속을 잡을 수 없어요!",
+                        description: "2시간 이후부터 약속을 잡을 수 있어요.",
+                        buttonTitle: "돌아가기") {
+                            viewStore.send(.alertButtonTapped)
+                        }
+                }
             }
         }
-        .padding()
     }
 }
 
@@ -50,7 +66,14 @@ struct CreateMeetingMemoView_Previews: PreviewProvider {
     static var previews: some View {
         CreateMemoView(
             store: Store(
-                initialState: CreateMemoFeature.State(),
+                initialState: CreateMemoFeature.State(
+                    meetingCreate: MeetingCreateModel(
+                        title: nil,
+                        place: nil,
+                        meetingTime: nil,
+                        memo: nil
+                    )
+                ),
                 reducer: CreateMemoFeature()
             )
         )

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Place/CreatePlaceFeature.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Place/CreatePlaceFeature.swift
@@ -37,8 +37,8 @@ struct CreatePlaceFeature: ReducerProtocol {
         // Delegate
         case delegate(Delegate)
 
-        enum Delegate {
-            case moveToNext
+        enum Delegate: Equatable {
+            case moveToNext(String)
         }
     }
 
@@ -69,7 +69,8 @@ struct CreatePlaceFeature: ReducerProtocol {
                 }
 
             case .moveToNextScreen:
-                return .run { send in await send(.delegate(.moveToNext)) }
+                let place = state.textFieldState.text
+                return .run { send in await send(.delegate(.moveToNext(place))) }
 
                 // TextField
             case let .textFieldAction(.textChanged(text)):

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleFeature.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleFeature.swift
@@ -14,7 +14,7 @@ struct CreateTitleFeature: ReducerProtocol {
     struct State: Equatable {
 
         // Create Model
-        var meetingCreate = MeetingCreateModel(title: nil, place: nil, meetingTime: nil, memo: nil)
+        var meetingCreate = MeetingCreateModel(title: nil, place: nil, time: nil, memo: nil)
         
         // Button
         var nextButtonDisabled: Bool = true
@@ -145,7 +145,7 @@ struct CreateTitleFeature: ReducerProtocol {
                 .element(id: id, action: .meetingDate(.delegate(.moveToNext(meetingTime))))
             ):
                 _ = id
-                state.meetingCreate = state.meetingCreate.update(meetingTime: meetingTime)
+                state.meetingCreate = state.meetingCreate.update(time: meetingTime)
                 state.path.append(.meetingMemo(
                     CreateMemoFeature.State(meetingCreate: state.meetingCreate))
                 )

--- a/Baggle/BaggleTests/BaggleDateTests.swift
+++ b/Baggle/BaggleTests/BaggleDateTests.swift
@@ -41,7 +41,7 @@ final class BaggleDateTests: XCTestCase {
     }
 
     // 시각 : 2023년 8월 5일 18시 51분
-    // 약속 생성 가능 시각 : 2023년 8월 5일 20시 55분
+    // 약속 생성 가능 시각 : 2023년 8월 5일 21시 00분
     // 테스트 결과값 : "2023년 8월 5일"
     func test_약속가능시간_생성_날짜_01() throws {
         let date = try testDateService.createDate(2023, 8, 5, 18, 51)
@@ -52,18 +52,18 @@ final class BaggleDateTests: XCTestCase {
     }
 
     // 시각 : 2023년 8월 5일 18시 51분
-    // 약속 생성 가능 시각 : 2023년 8월 5일 20시 55분
-    // 테스트 결과값 : "20:55"
+    // 약속 생성 가능 시각 : 2023년 8월 5일 21시 00분
+    // 테스트 결과값 : "21:00"
     func test_약속가능시간_생성_시간_01() throws {
         let date = try testDateService.createDate(2023, 8, 5, 18, 51)
         let meetingDate = date.meetingStartTime()
         let result = meetingDate.hourMinute()
 
-        XCTAssertEqual(result, "20:55")
+        XCTAssertEqual(result, "21:00")
     }
 
     // 시각 : 2023년 8월 20일 22시 33분
-    // 약속 생성 가능 시각 : 2023년 8월 21일 00시 35분
+    // 약속 생성 가능 시각 : 2023년 8월 21일 00시 40분
     // 테스트 결과값 : "2023년 8월 21일"
     func test_약속가능시간_생성_날짜_02() throws {
         let date = try testDateService.createDate(2023, 8, 20, 22, 33)
@@ -74,18 +74,18 @@ final class BaggleDateTests: XCTestCase {
     }
 
     // 시각 : 2023년 8월 20일 22시 33분
-    // 약속 생성 가능 시각 : 2023년 8월 21일 00시 35분
-    // 테스트 결과값 : "00:35"
+    // 약속 생성 가능 시각 : 2023년 8월 21일 00시 40분
+    // 테스트 결과값 : "00:40"
     func test_약속가능시간_생성_시간_02() throws {
         let date = try testDateService.createDate(2023, 8, 20, 22, 33)
         let meetingDate = date.meetingStartTime()
         let result = meetingDate.hourMinute()
 
-        XCTAssertEqual(result, "00:35")
+        XCTAssertEqual(result, "00:40")
     }
 
     // 시각 : 2023년 9월 2일 16시 05분
-    // 약속 생성 가능 시각 : 2023년 9월 2일 18시 10분
+    // 약속 생성 가능 시각 : 2023년 9월 2일 18시 15분
     // 테스트 결과값 : "2023년 9월 2일"
     func test_약속가능시간_생성_날짜_03() throws {
         let date = try testDateService.createDate(2023, 9, 2, 16, 05)
@@ -96,18 +96,18 @@ final class BaggleDateTests: XCTestCase {
     }
 
     // 시각 : 2023년 9월 2일 16시 05분
-    // 약속 생성 가능 시각 : 2023년 9월 2일 18시 10분
-    // 테스트 결과값 : "18:10"
+    // 약속 생성 가능 시각 : 2023년 9월 2일 18시 15분
+    // 테스트 결과값 : "18:15"
     func test_약속가능시간_생성_시간_03() throws {
         let date = try testDateService.createDate(2023, 9, 2, 16, 05)
         let meetingDate = date.meetingStartTime()
         let result = meetingDate.hourMinute()
 
-        XCTAssertEqual(result, "18:10")
+        XCTAssertEqual(result, "18:15")
     }
 
     // 시각 : 2023년 8월 31일 21시 57분
-    // 약속 생성 가능 시각 : 2023년 9월 1일 0시 0분
+    // 약속 생성 가능 시각 : 2023년 9월 1일 0시 5분
     // 테스트 결과값 : "2023년 9월 2일"
     func test_약속가능시간_생성_날짜_04() throws {
         let date = try testDateService.createDate(2023, 8, 31, 21, 57)
@@ -118,32 +118,32 @@ final class BaggleDateTests: XCTestCase {
     }
 
     // 시각 : 2023년 8월 31일 21시 57분
-    // 약속 생성 가능 시각 : 2023년 9월 1일 0시 0분
-    // 테스트 결과값 : "0:00"
+    // 약속 생성 가능 시각 : 2023년 9월 1일 0시 5분
+    // 테스트 결과값 : "00:05"
     func test_약속가능시간_생성_시간_04() throws {
         let date = try testDateService.createDate(2023, 8, 31, 21, 57)
         let meetingDate = date.meetingStartTime()
         let result = meetingDate.hourMinute()
 
-        XCTAssertEqual(result, "00:00")
+        XCTAssertEqual(result, "00:05")
     }
 
-    // 시각 : 2023년 12월 31일 21시 57분
+    // 시각 : 2023년 12월 31일 21시 52분
     // 약속 생성 가능 시각 : 2024년 1월 1일 0시 0분
     // 테스트 결과값 : "2024년 1월 1일"
     func test_약속가능시간_생성_날짜_05() throws {
-        let date = try testDateService.createDate(2023, 12, 31, 21, 57)
+        let date = try testDateService.createDate(2023, 12, 31, 21, 52)
         let meetingDate = date.meetingStartTime()
         let result = meetingDate.koreanDate()
 
         XCTAssertEqual(result, "2024년 1월 1일")
     }
 
-    // 시각 : 2023년 12월 31일 21시 57분
+    // 시각 : 2023년 12월 31일 21시 52분
     // 약속 생성 가능 시각 : 2024년 1월 1일 0시 0분
     // 테스트 결과값 : "0:00"
     func test_약속가능시간_생성_시간_05() throws {
-        let date = try testDateService.createDate(2024, 12, 31, 21, 57)
+        let date = try testDateService.createDate(2024, 12, 31, 21, 52)
         let meetingDate = date.meetingStartTime()
         let result = meetingDate.hourMinute()
 
@@ -151,7 +151,7 @@ final class BaggleDateTests: XCTestCase {
     }
 
     // 시각 : 2024년 2월 28일 23시 00분
-    // 약속 생성 가능 시각 : 2024년 2월 29일 1시 5분
+    // 약속 생성 가능 시각 : 2024년 2월 29일 1시 10분
     // 테스트 결과값 : "2024년 2월 29일"
     func test_약속가능시간_생성_날짜_06() throws {
         let date = try testDateService.createDate(2024, 2, 28, 23, 00)
@@ -162,13 +162,13 @@ final class BaggleDateTests: XCTestCase {
     }
 
     // 시각 : 2024년 2월 28일 23시 00분
-    // 약속 생성 가능 시각 : 2024년 2월 29일 1시 5분
-    // 테스트 결과값 : "01:05"
+    // 약속 생성 가능 시각 : 2024년 2월 29일 1시 10분
+    // 테스트 결과값 : "01:10"
     func test_약속가능시간_생성_시간_06() throws {
         let date = try testDateService.createDate(2024, 2, 28, 23, 00)
         let meetingDate = date.meetingStartTime()
         let result = meetingDate.hourMinute()
 
-        XCTAssertEqual(result, "01:05")
+        XCTAssertEqual(result, "01:10")
     }
 }


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #64

## 내용
<!--
로직 설명  
--> 
- 모임 생성시 편의를 위해 날짜 자동 선택기능을 추가했습니다. 화면 진입시 자동으로 날짜 선택 View가 나타납니다.
- 모임 생성 최종 화면인 메모 생성 화면에서 다음 버튼 클릭시, 모임 생성 가능한지 한 번더 확인합니다. 모임 생성이 불가능한 경우 Alert을 띄우고 전 화면으로 이동합니다. 아래 영상 참고해주세요.
- 모임 생성 날짜 로직을 수정했습니다.
  - 기존 14:04 -> 16:05, 14:05 -> 16:05
  - 수정 이후 14:04 -> 16:10, 14:05 -> 16:15
  - 수정한 이유는 메모 작성시간이 위 예시처럼 1분 밖에 안되는 경우가 있기 때문입니다. 약속 시간을 16시 05분이라 하겠습니다. 시간 생성 화면 통과시에 14:04:40로 통과하고 메모 작성하고 있는데 14:05가 되어, 다음 버튼 클릭시 생성할 수 없다는 Alert이 뜹니다. 메모 생성에 더 여유로운 시간을 주고자 시간 로직을 수정해주었습니다.
- 모임 생성을 위한 MeetingCreateModel을 생성했습니다. 화면이 여러 개라 각각의 State를 어떻게 관리할까 고민했습니다. 아래 이미지와 같이 구현했습니다.
  - 함수형 프로그래밍을 위해 모델 업데이트시 새로운 모델을 리턴합니다.
  - 최대한 역할 분리를 위해서 화면에서는 자신의 State만 가지도록 했습니다.
  - 제목 생성 화면의 경우 다른 뷰들의 Root Navigation View이므로 모델(=MeetingCreateModel)을 가지고 있습니다.
  - 장소 생성 View의 경우, TextField의 입력된 장소(=place)를 delegate를 통해 전달합니다. (날짜 생성도 마찬가지)
  - `메모 생성` 화면의 경우에는 네트워크 요청을 위해 모델이 필요하므로 `제목 생성` -> `메모 생성`으로 모델을 전달해주었습니다. `제목 생성`에서만 모델을 가질까 했는데, 그러면 `메모 생성`에서 네트워크 요청하고, 화면 로딩 보여주고 이런 로직을 `제목 생성`에서 진행하고 다시 결과를 전달하는 과정이 너무 복잡해져 이와 같이 구성했습니다.

![Section 1](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/523226ba-2561-4644-855a-70b58f09b48e)

이미지 보고 질문 마음껏 해주세요.

<br/>

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

날짜 자동 선택

![Simulator Screen Recording - iPhone 14 Pro - 2023-08-15 at 14 27 43](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/f077de82-facf-4c74-b847-e53d163a8dfa)

메모 생성 화면에서 시간 확인 로직

![Simulator Screen Recording - iPhone 14 Pro - 2023-08-15 at 14 26 28](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/01257fe6-7282-4600-abeb-f73572c5c44d)


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- ~~PR 작성하면서 테스트 수정 안 한게 생각났어요 😅 수정하고 있겠습니다.~~ 테스트 수정 완료했습니다.

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
