### PR TITLE
Fix - 카카오 로그인 버튼 수정, Font+ 수정

### DIFF
--- a/Baggle/Baggle/DesignSystem/Extension/Font+.swift
+++ b/Baggle/Baggle/DesignSystem/Extension/Font+.swift
@@ -9,40 +9,55 @@ import SwiftUI
 
 enum FontType {
     case title
-    case subTitle
-    case button
+    case subTitle1
+    case subTitle2
+    case button1
+    case button2
     case body1
     case body2
     case body3
-    case description
+    case description1
+    case description2
     case caption1
     case caption2
+    case caption3
+    case caption4
 
     var size: CGFloat {
         switch self {
         case .title: return 24
-        case .subTitle: return 22
-        case .button: return 16
+        case .subTitle1: return 22
+        case .subTitle2: return 20
+        case .button1: return 16
+        case .button2: return 15
         case .body1: return 18
         case .body2: return 16
         case .body3: return 15
-        case .description: return 14
+        case .description1: return 14
+        case .description2: return 14
         case .caption1: return 13
-        case .caption2: return 12
+        case .caption2: return 13
+        case .caption3: return 12
+        case .caption4: return 12
         }
     }
     
     var weight: Font.Weight {
         switch self {
         case .title: return .bold
-        case .subTitle: return .bold
-        case .button: return .semibold
+        case .subTitle1: return .bold
+        case .subTitle2: return .bold
+        case .button1: return .semibold
+        case .button2: return .bold
         case .body1: return .bold
         case .body2: return .medium
         case .body3: return .medium
-        case .description: return .medium
-        case .caption1: return .medium
-        case .caption2: return .semibold
+        case .description1: return .semibold
+        case .description2: return .medium
+        case .caption1: return .bold
+        case .caption2: return .medium
+        case .caption3: return .semibold
+        case .caption4: return .medium
         }
     }
 }
@@ -65,13 +80,18 @@ extension Font {
 extension Font {
     struct Baggle {
         static let title = Font.baggleFont(fontType: .title)
-        static let subTitle = Font.baggleFont(fontType: .subTitle)
-        static let button = Font.baggleFont(fontType: .button)
+        static let subTitle1 = Font.baggleFont(fontType: .subTitle1)
+        static let subTitle2 = Font.baggleFont(fontType: .subTitle2)
+        static let button1 = Font.baggleFont(fontType: .button1)
+        static let button2 = Font.baggleFont(fontType: .button2)
         static let body1 = Font.baggleFont(fontType: .body1)
         static let body2 = Font.baggleFont(fontType: .body2)
         static let body3 = Font.baggleFont(fontType: .body3)
-        static let description = Font.baggleFont(fontType: .description)
+        static let description1 = Font.baggleFont(fontType: .description1)
+        static let description2 = Font.baggleFont(fontType: .description2)
         static let caption1 = Font.baggleFont(fontType: .caption1)
         static let caption2 = Font.baggleFont(fontType: .caption2)
+        static let caption3 = Font.baggleFont(fontType: .caption3)
+        static let caption4 = Font.baggleFont(fontType: .caption4)
     }
 }

--- a/Baggle/Baggle/DesignSystem/Extension/Font+.swift
+++ b/Baggle/Baggle/DesignSystem/Extension/Font+.swift
@@ -75,6 +75,17 @@ extension Font {
         default: return .custom("AppleSDGothicNeo-Regular", size: size)
         }
     }
+    
+    static func baggleFont(size: CGFloat, weight: Font.Weight) -> Font {
+        
+        switch weight {
+        case .bold: return .custom("AppleSDGothicNeo-Bold", size: size)
+        case .semibold: return .custom("AppleSDGothicNeo-SemiBold", size: size)
+        case .medium: return .custom("AppleSDGothicNeo-Medium", size: size)
+        case .regular: return .custom("AppleSDGothicNeo-Regular", size: size)
+        default: return .custom("AppleSDGothicNeo-Regular", size: size)
+        }
+    }
 }
 
 extension Font {

--- a/Baggle/Baggle/DesignSystem/Extension/Font+.swift
+++ b/Baggle/Baggle/DesignSystem/Extension/Font+.swift
@@ -31,14 +31,28 @@ enum FontType {
         case .caption2: return 12
         }
     }
+    
+    var weight: Font.Weight {
+        switch self {
+        case .title: return .bold
+        case .subTitle: return .bold
+        case .button: return .semibold
+        case .body1: return .bold
+        case .body2: return .medium
+        case .body3: return .medium
+        case .description: return .medium
+        case .caption1: return .medium
+        case .caption2: return .semibold
+        }
+    }
 }
 
 extension Font {
-    static func baggleFont(fontType: FontType, weight: Font.Weight) -> Font {
+    static func baggleFont(fontType: FontType) -> Font {
         
         let size = fontType.size
         
-        switch weight {
+        switch fontType.weight {
         case .bold: return .custom("AppleSDGothicNeo-Bold", size: size)
         case .semibold: return .custom("AppleSDGothicNeo-SemiBold", size: size)
         case .medium: return .custom("AppleSDGothicNeo-Medium", size: size)
@@ -50,28 +64,14 @@ extension Font {
 
 extension Font {
     struct Baggle {
-        static let title = Font.baggleFont(fontType: .title, weight: .bold)
-        static let subTitle = Font.baggleFont(fontType: .subTitle, weight: .bold)
-        static let button = Font.baggleFont(fontType: .button, weight: .semibold)
-        static let body1 = Font.baggleFont(fontType: .body1, weight: .bold)
-        static let body2 = Font.baggleFont(fontType: .body2, weight: .medium)
-        static let body3 = Font.baggleFont(fontType: .body3, weight: .medium)
-        static let description = Font.baggleFont(fontType: .description, weight: .medium)
-        static let caption1 = Font.baggleFont(fontType: .caption1, weight: .medium)
-        static let caption2 = Font.baggleFont(fontType: .caption2, weight: .semibold)
-        
-        static func font(_ fontType: FontType) -> Font {
-            switch fontType {
-            case .title: return self.title
-            case .subTitle: return self.subTitle
-            case .button: return self.button
-            case .body1: return self.body1
-            case .body2: return self.body2
-            case .body3: return self.body3
-            case .description: return self.description
-            case .caption1: return self.caption1
-            case .caption2: return self.caption2
-            }
-        }
+        static let title = Font.baggleFont(fontType: .title)
+        static let subTitle = Font.baggleFont(fontType: .subTitle)
+        static let button = Font.baggleFont(fontType: .button)
+        static let body1 = Font.baggleFont(fontType: .body1)
+        static let body2 = Font.baggleFont(fontType: .body2)
+        static let body3 = Font.baggleFont(fontType: .body3)
+        static let description = Font.baggleFont(fontType: .description)
+        static let caption1 = Font.baggleFont(fontType: .caption1)
+        static let caption2 = Font.baggleFont(fontType: .caption2)
     }
 }

--- a/Baggle/Baggle/DesignSystem/Extension/View+Modifier.swift
+++ b/Baggle/Baggle/DesignSystem/Extension/View+Modifier.swift
@@ -43,7 +43,7 @@ extension View {
     /// baggleFont + lineSpacing 설정하는 함수
     func fontWithLineSpacing(fontType: FontType) -> some View {
         return self
-            .font(.Baggle.font(fontType))
+            .font(.Baggle.body2)
             .lineSpacing(fontType.size * 0.3)
     }
 

--- a/Baggle/Baggle/DesignSystem/View/Bubble/BubbleView.swift
+++ b/Baggle/Baggle/DesignSystem/View/Bubble/BubbleView.swift
@@ -16,7 +16,7 @@ struct BubbleView: View {
     var body: some View {
         VStack(spacing: -3) {
             Text(text)
-                .font(.Baggle.caption1)
+                .font(.Baggle.caption2)
                 .foregroundColor(color.foregroundColor)
                 .padding(.vertical, size.paddingVertical)
                 .padding(.horizontal, size.paddingHorizontal)

--- a/Baggle/Baggle/DesignSystem/View/Button/BaggleButtonStyle.swift
+++ b/Baggle/Baggle/DesignSystem/View/Button/BaggleButtonStyle.swift
@@ -173,7 +173,7 @@ struct KakaoLoginStyle: ButtonStyle {
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .font(.Baggle.body2) // bold
+            .font(.baggleFont(size: 20, weight: .semibold))
             .frame(width: UIScreen.main.bounds.width - 40, height: 54)
             .foregroundColor(foregroundColor(configuration.isPressed))
             .background(backgroundColor(configuration.isPressed))

--- a/Baggle/Baggle/DesignSystem/View/Tag/BaggleTag.swift
+++ b/Baggle/Baggle/DesignSystem/View/Tag/BaggleTag.swift
@@ -19,7 +19,7 @@ struct BaggleTag: View {
 
     var body: some View {
         Text(text)
-            .font(.Baggle.caption2)
+            .font(.Baggle.caption3)
             .kerning(-0.5)
             .padding(.horizontal, 10)
             .padding(.vertical, 6)

--- a/Baggle/Baggle/DesignSystem/View/Text/TextEditor/BaggleTextEditor.swift
+++ b/Baggle/Baggle/DesignSystem/View/Text/TextEditor/BaggleTextEditor.swift
@@ -89,7 +89,7 @@ struct BaggleTextEditor: View {
 
                 if case let .invalid(error) = viewStore.textFieldState {
                     Text(error)
-                        .font(.Baggle.caption2)
+                        .font(.Baggle.caption3)
                         .padding(.horizontal, 8)
                         .padding(.top, 8)
                         .foregroundColor(viewStore.textFieldState.fgColor)

--- a/Baggle/Baggle/DesignSystem/View/Text/TextField/BaggleTextField.swift
+++ b/Baggle/Baggle/DesignSystem/View/Text/TextField/BaggleTextField.swift
@@ -87,7 +87,7 @@ struct BaggleTextField: View {
 
                 if case let .title(title) = title {
                     Text(title)
-                        .font(.Baggle.description)
+                        .font(.Baggle.description2)
                         .padding(.horizontal, 2)
                         .padding(.bottom, 6)
                         .foregroundColor(.gray6)
@@ -106,7 +106,7 @@ struct BaggleTextField: View {
                     .foregroundColor(viewStore.textFieldState.fgColor)
 
                     Text("\(viewStore.text.count)/\(viewStore.maxCount)")
-                        .font(.Baggle.description)
+                        .font(.Baggle.description2)
                         .foregroundColor(viewStore.textFieldState.fgColor)
 
                     if viewStore.state.textFieldState == .active {
@@ -134,7 +134,7 @@ struct BaggleTextField: View {
 
                 if case let .invalid(error) = viewStore.textFieldState {
                     Text(error)
-                        .font(.Baggle.caption2)
+                        .font(.Baggle.caption3)
                         .padding(.horizontal, 8)
                         .padding(.top, 8)
                         .foregroundColor(viewStore.textFieldState.fgColor)

--- a/Baggle/Baggle/Features/Camera/CameraView.swift
+++ b/Baggle/Baggle/Features/Camera/CameraView.swift
@@ -60,7 +60,7 @@ extension CameraView {
     private func description(viewStore: CameraFeatureViewStore) -> some View {
         Text("실시간 상황을\n친구들에게 공유하세요!")
             .multilineTextAlignment(.center)
-            .fontWithLineSpacing(fontType: .subTitle)
+            .fontWithLineSpacing(fontType: .subTitle1)
             .foregroundColor(.white)
     }
     
@@ -240,7 +240,7 @@ extension CameraView {
             )
             
             Text("시간이 초과되었습니다.")
-                .font(.Baggle.subTitle)
+                .font(.Baggle.subTitle1)
                 .foregroundColor(.white)
                 .padding(.horizontal, 20)
                 .padding(.vertical, 16)

--- a/Baggle/Baggle/Features/JoinMeeting/JoinMeetingView.swift
+++ b/Baggle/Baggle/Features/JoinMeeting/JoinMeetingView.swift
@@ -54,7 +54,7 @@ extension JoinMeetingView {
         VStack {
             Text("약속 초대장이 도착했어요!\n참여하시겠어요?")
                 .multilineTextAlignment(.center)
-                .font(.Baggle.subTitle)
+                .font(.Baggle.subTitle1)
                 .foregroundColor(.primaryNormal)
                 .padding(.vertical, 8)
             
@@ -93,7 +93,7 @@ extension JoinMeetingView {
                             targetColor: .gray6)
                     )
                 }
-                .font(.Baggle.description)
+                .font(.Baggle.description2)
             }
             
             Spacer()

--- a/Baggle/Baggle/Features/Login/LoginFeature.swift
+++ b/Baggle/Baggle/Features/Login/LoginFeature.swift
@@ -48,16 +48,12 @@ struct LoginFeature: ReducerProtocol {
 
             case .appleLoginButtonTapped(let token):
                 print("🍎 확인용 - token: \(token)")
-                let requestModel = LoginRequestModel(platform: .apple,
-                                                     fcmToken: UserDefaultList.fcmToken ?? "")
                 return .run { send in
                     // 로그인 통신
                     await send(.requestLogin(.apple, token))
                 }
 
             case .kakaoLoginButtonTapped:
-                let requestModel = LoginRequestModel(platform: .kakao,
-                                                     fcmToken: UserDefaultList.fcmToken ?? "")
                 return .run { send in
                     do {
                         let token = try await loginService.kakaoLogin()

--- a/Baggle/Baggle/Features/Login/LoginView.swift
+++ b/Baggle/Baggle/Features/Login/LoginView.swift
@@ -66,7 +66,7 @@ extension LoginView {
             HStack(spacing: 6) {
                 Image.Icon.kakao
 
-                Text("카카오로 계속하기")
+                Text("카카오로 로그인")
             }
         }
         .buttonStyle(KakaoLoginStyle())

--- a/Baggle/Baggle/Features/Login/SignUp/Main/SignUpView.swift
+++ b/Baggle/Baggle/Features/Login/SignUp/Main/SignUpView.swift
@@ -106,7 +106,7 @@ extension SignUpView {
             
             Text("설정해주세요.")
         }
-        .font(.Baggle.subTitle)
+        .font(.Baggle.subTitle1)
         .padding(.vertical, 12)
     }
 

--- a/Baggle/Baggle/Features/Login/SignUp/Success/SignUpSuccessView.swift
+++ b/Baggle/Baggle/Features/Login/SignUp/Success/SignUpSuccessView.swift
@@ -67,7 +67,7 @@ extension SignUpSuccessView {
                 
                 Text("환영합니다!")
             }
-            .fontWithLineSpacing(fontType: .subTitle)
+            .fontWithLineSpacing(fontType: .subTitle1)
             .foregroundColor(.primaryNormal)
             .padding(.vertical, 8)
 

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
@@ -138,7 +138,7 @@ extension MeetingDetailView {
             Text("📌")
 
             Text("\(name)")
-                .fontWithLineSpacing(fontType: .subTitle)
+                .fontWithLineSpacing(fontType: .subTitle1)
                 .frame(maxWidth: name.width > 200 ? 200 : .none, alignment: .leading)
                 .padding(.trailing, 4)
                 .foregroundColor(.gray9)
@@ -252,7 +252,7 @@ extension MeetingDetailView {
 
                         Text(member.name)
                             .padding(.vertical, 2)
-                            .fontWithLineSpacing(fontType: .caption1)
+                            .fontWithLineSpacing(fontType: .caption2)
                             .frame(maxWidth: 64)
                     }
                     .padding(.all, 2)

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Common/CircleNumberView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Common/CircleNumberView.swift
@@ -19,7 +19,7 @@ struct CircleNumberView: View {
                 .frame(width: 22, height: 22)
 
             Text(number)
-                .font(.Baggle.caption2)
+                .font(.Baggle.caption3)
                 .foregroundColor(.white)
         }
     }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Common/CreateDescription.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Common/CreateDescription.swift
@@ -20,7 +20,7 @@ struct CreateDescription: View {
 
             HStack {
                 Text(title)
-                    .font(.Baggle.subTitle)
+                    .font(.Baggle.subTitle1)
                     .foregroundColor(.gray11)
                 Spacer()
             }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Date/CreateDateView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Date/CreateDateView.swift
@@ -29,7 +29,7 @@ struct CreateDateView: View {
                     VStack(alignment: .leading) {
 
                         Text("날짜와 시간을 입력하세요.")
-                            .font(.Baggle.description)
+                            .font(.Baggle.description2)
                             .foregroundColor(.gray6)
                             .padding(.horizontal, 2)
                         
@@ -76,7 +76,7 @@ struct CreateDateView: View {
 
                         if let errorMessage = viewStore.errorMessage {
                             Text(errorMessage)
-                                .font(.Baggle.caption2)
+                                .font(.Baggle.caption3)
                                 .foregroundColor(.baggleRed)
                                 .padding(.horizontal, 2)
                         }

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Success/CreateSuccessView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Success/CreateSuccessView.swift
@@ -22,7 +22,7 @@ struct CreateSuccessView: View {
 
                 VStack {
                     Text("약속이 만들어졌어요!")
-                        .font(.Baggle.subTitle)
+                        .font(.Baggle.subTitle1)
                         .foregroundColor(.primaryNormal)
                         .padding(.vertical, 8)
 
@@ -60,7 +60,7 @@ struct CreateSuccessView: View {
                                     targetColor: .gray6
                                 )
                             )
-                            .font(.Baggle.description)
+                            .font(.Baggle.description2)
 
                             Text(
                                 attributedColorString(
@@ -70,7 +70,7 @@ struct CreateSuccessView: View {
                                     targetColor: .gray6
                                 )
                             )
-                            .font(.Baggle.description)
+                            .font(.Baggle.description2)
                         }
                     }
                     .padding(.vertical, 28)

--- a/Baggle/Baggle/Features/Tab/Home/Common/MeetingListCell.swift
+++ b/Baggle/Baggle/Features/Tab/Home/Common/MeetingListCell.swift
@@ -38,7 +38,7 @@ struct MeetingListCell: View {
                             targetColor: .gray6
                         )
                     )
-                    .font(.Baggle.description)
+                    .font(.Baggle.description2)
 
                     Text(
                         attributedColorString(
@@ -47,7 +47,7 @@ struct MeetingListCell: View {
                             color: .gray9,
                             targetColor: .gray6)
                     )
-                    .font(.Baggle.description)
+                    .font(.Baggle.description2)
                 }
 
                 HStack {
@@ -65,7 +65,7 @@ struct MeetingListCell: View {
                     Spacer()
 
                     Text("참여자 \(data.profileImages.count)명")
-                        .font(.Baggle.description)
+                        .font(.Baggle.description2)
                         .foregroundColor(.gray11)
                 }
             }

--- a/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
@@ -46,7 +46,7 @@ struct MyPageView: View {
                                 
                                 HStack(alignment: .top, spacing: 6) {
                                     Text(viewStore.user.name)
-                                        .font(.Baggle.subTitle)
+                                        .font(.Baggle.subTitle1)
                                         .foregroundColor(.gray11)
                                     
                                     PlatformLogoView(platform: viewStore.user.platform)

--- a/Baggle/Baggle/Features/Tab/MyPage/Setting/SettingListHeader.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/Setting/SettingListHeader.swift
@@ -15,7 +15,7 @@ struct SettingListHeader: View {
         
         HStack {
             Text(text)
-                .font(.Baggle.description)
+                .font(.Baggle.description2)
                 .foregroundColor(.gray6)
             
             Spacer()

--- a/Baggle/Baggle/Features/Tab/MyPage/Setting/SettingListRow.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/Setting/SettingListRow.swift
@@ -26,7 +26,7 @@ struct SettingListRow: View {
             HStack {
                 Text(text)
                     .foregroundColor(.gray11)
-                    .font(.Baggle.button)
+                    .font(.Baggle.button1)
                 
                 Spacer()
                 


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
close #160 

## 내용
<!--
로직 설명  
--> 
1. 카카오 로그인 버튼 타이틀, 폰트 변경
2. FontType에 weight 추가 + 기존 함수 수정
3. 디자인 타이포 스타일 변경 사항 반영

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 
<img src="https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/0448ced7-337f-4e6e-915f-da25d27bafdb" width=300>


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- FontType에 weight를 함께 정의해서 Baggle 구조체 내부에 새롭게 정의하지 않고, `baggleFont(fontType:)` 만 있어도 괜찮을 것 같은데 어떠신가요?
  - `.Baggle.font` 처럼 static 변수로 관리하다보면 FontType에서 타이포 스타일을 추가하고, 구조체 내부에 한번 더 정의해줘야 하는 번거로움이 조금 있는 것 같아서 
  - `.baggleFont(.font)`만 사용한다면 size와 weight만 한번씩 FontType에 추가하면 된다는 장점이 있을 것 같습니다.
  - 대신 기존에 적용해둔 `.Baggle.font`를 전체적으로 수정해야 합니다.. 
- 타이포 스타일 추가되면서 기존 스타일도 수정된게 쫌 있어서 반영해뒀습니다
  - ex) 기존의 caption1 스타일 -> 현재 caption2 스타일

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
