### PR TITLE
Fix - 마이페이지 유저 정보 onAppear 불러오도록 수정

### DIFF
--- a/Baggle/Baggle/Features/Tab/MyPage/MyPageFeature.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/MyPageFeature.swift
@@ -20,6 +20,8 @@ struct MyPageFeature: ReducerProtocol {
     }
 
     enum Action: Equatable {
+        case onAppear
+        
         case logoutMyPage
 
         case notificationSettingButtonTapped
@@ -43,6 +45,9 @@ struct MyPageFeature: ReducerProtocol {
 
         Reduce { state, action in
             switch action {
+            case .onAppear:
+                state.user = UserDefaultList.user ?? User.error()
+                return .none
 
             case .logoutMyPage:
                 return .none

--- a/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
@@ -103,6 +103,9 @@ struct MyPageView: View {
                 .listRowInsets(EdgeInsets())
                 .listStyle(.plain)
             }
+            .onAppear {
+                viewStore.send(.onAppear)
+            }
             .fullScreenCover(
                 isPresented: viewStore.binding(
                     get: \.presentSafariView,


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
close #163 

## 내용
<!--
로직 설명  
--> 
마이페이지 유저 정보 onAppear에서 불러오도록 수정

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

애플 로그인 상태 -> 로그아웃 -> 카카오 로그인 -> 로그아웃 -> 애플 로그인


https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/6d16be5e-919d-4c9b-ab94-e674d670a0ed


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
