### PR TITLE
이미지 다운 스케일 & 압축

### DIFF
--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		144733442A78C8D00090D15E /* BaggleTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144733432A78C8D00090D15E /* BaggleTextEditor.swift */; };
 		14486D2C2A8B0C7400831DDD /* DateFormatter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14486D2B2A8B0C7400831DDD /* DateFormatter+.swift */; };
 		14486D2E2A8B0D2900831DDD /* Print+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14486D2D2A8B0D2900831DDD /* Print+.swift */; };
+		145210892A8E2D7800150C57 /* ImageSizeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 145210882A8E2D7800150C57 /* ImageSizeType.swift */; };
 		1461B6002A7BA3F000A15706 /* BubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1461B5FF2A7BA3F000A15706 /* BubbleView.swift */; };
 		1461B6022A7BA8C500A15706 /* RoundedTriangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1461B6012A7BA8C500A15706 /* RoundedTriangle.swift */; };
 		1462373E2A87760E00FBE121 /* SettingListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1462373D2A87760E00FBE121 /* SettingListRow.swift */; };
@@ -265,6 +266,7 @@
 		144733432A78C8D00090D15E /* BaggleTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggleTextEditor.swift; sourceTree = "<group>"; };
 		14486D2B2A8B0C7400831DDD /* DateFormatter+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+.swift"; sourceTree = "<group>"; };
 		14486D2D2A8B0D2900831DDD /* Print+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Print+.swift"; sourceTree = "<group>"; };
+		145210882A8E2D7800150C57 /* ImageSizeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSizeType.swift; sourceTree = "<group>"; };
 		1461B5FF2A7BA3F000A15706 /* BubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleView.swift; sourceTree = "<group>"; };
 		1461B6012A7BA8C500A15706 /* RoundedTriangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedTriangle.swift; sourceTree = "<group>"; };
 		1462373D2A87760E00FBE121 /* SettingListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingListRow.swift; sourceTree = "<group>"; };
@@ -785,6 +787,15 @@
 			path = MockUp;
 			sourceTree = "<group>";
 		};
+		145210872A8E2D6B00150C57 /* UIImage */ = {
+			isa = PBXGroup;
+			children = (
+				143410532A7E87460024FC75 /* UIImage+.swift */,
+				145210882A8E2D7800150C57 /* ImageSizeType.swift */,
+			);
+			path = UIImage;
+			sourceTree = "<group>";
+		};
 		1461B5FE2A7BA3EA00A15706 /* Bubble */ = {
 			isa = PBXGroup;
 			children = (
@@ -1170,11 +1181,11 @@
 			isa = PBXGroup;
 			children = (
 				146C51DE2A79143400FF3142 /* Date */,
+				145210872A8E2D6B00150C57 /* UIImage */,
 				2BABCB272A76D08300AFECA3 /* PostObserverAction.swift */,
 				14F2D7B02A728A2B000ED0EE /* PhotosPickerItem+loadTransferable.swift */,
 				140C543D2A74F54B00CF1CB4 /* String+.swift */,
 				14783EE72A7E340E00EF58D5 /* CIImage+.swift */,
-				143410532A7E87460024FC75 /* UIImage+.swift */,
 				1493A9172A7E01D800A2D7CC /* Int+.swift */,
 				2B7EC32C2A822E5B00D78141 /* UINavigationController+.swift */,
 				14486D2D2A8B0D2900831DDD /* Print+.swift */,
@@ -1612,6 +1623,7 @@
 				2BB6BA902A82039300F04188 /* MeetingDetailButtonType.swift in Sources */,
 				1461B6002A7BA3F000A15706 /* BubbleView.swift in Sources */,
 				141FD7632A8CF609003DBFD7 /* MeetingSuccessModel.swift in Sources */,
+				145210892A8E2D7800150C57 /* ImageSizeType.swift in Sources */,
 				146237462A877CFB00FBE121 /* PlatformLogoView.swift in Sources */,
 				2B84696D2A6E7AE200D75D32 /* ShadeView.swift in Sources */,
 				2BABCB282A76D08400AFECA3 /* PostObserverAction.swift in Sources */,

--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		14038B572A8DF6F200A7C964 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14038B562A8DF6F200A7C964 /* Image.swift */; };
 		1406858B2A7B676D00824A93 /* CreateDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1406858A2A7B676D00824A93 /* CreateDescription.swift */; };
 		140C54382A74F42900CF1CB4 /* NicknameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140C54372A74F42900CF1CB4 /* NicknameValidator.swift */; };
 		140E88112A64B626005119F8 /* BaggleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140E88102A64B626005119F8 /* BaggleApp.swift */; };
@@ -78,8 +79,8 @@
 		14783EE62A7E33B600EF58D5 /* CameraService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14783EE52A7E33B600EF58D5 /* CameraService.swift */; };
 		14783EE82A7E340E00EF58D5 /* CIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14783EE72A7E340E00EF58D5 /* CIImage+.swift */; };
 		1478999A2A7A0BC20071DAE3 /* DateInputStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147899992A7A0BC20071DAE3 /* DateInputStatus.swift */; };
-		147DFC812A8D191D00D176D1 /* JSONNULL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147DFC802A8D191D00D176D1 /* JSONNULL.swift */; };
 		147DFC7E2A8D124400D176D1 /* MeetingCreateEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147DFC7D2A8D124400D176D1 /* MeetingCreateEntity.swift */; };
+		147DFC812A8D191D00D176D1 /* JSONNULL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147DFC802A8D191D00D176D1 /* JSONNULL.swift */; };
 		147E81382A8A3790008B9B06 /* MeetingDetailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147E81372A8A3790008B9B06 /* MeetingDetailService.swift */; };
 		147E813A2A8A3924008B9B06 /* MeetingDetailStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147E81392A8A3924008B9B06 /* MeetingDetailStatus.swift */; };
 		1493A9102A7DE4A500A2D7CC /* TimerFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1493A90F2A7DE4A500A2D7CC /* TimerFeature.swift */; };
@@ -210,6 +211,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		14038B562A8DF6F200A7C964 /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		1406858A2A7B676D00824A93 /* CreateDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDescription.swift; sourceTree = "<group>"; };
 		140C54372A74F42900CF1CB4 /* NicknameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameValidator.swift; sourceTree = "<group>"; };
 		140C543D2A74F54B00CF1CB4 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
@@ -1344,6 +1346,7 @@
 			isa = PBXGroup;
 			children = (
 				2BB7FBC42A89289E0003B75C /* URL.swift */,
+				14038B562A8DF6F200A7C964 /* Image.swift */,
 				1471ECFA2A8A465C00D9FC93 /* ErrorID.swift */,
 				2BB7FBC62A892A520003B75C /* Const.swift */,
 			);
@@ -1615,6 +1618,7 @@
 				140E88132A64B626005119F8 /* AppView.swift in Sources */,
 				2B7B4D722A84A5C800283248 /* Meeting.swift in Sources */,
 				14E506502A6B8913008D5778 /* SignUpFeature.swift in Sources */,
+				14038B572A8DF6F200A7C964 /* Image.swift in Sources */,
 				2B2AFF882A8BE05D0028C96F /* EmergencyService.swift in Sources */,
 				2BABCB262A76D03300AFECA3 /* AppDelegate.swift in Sources */,
 				14783EE42A7E330D00EF58D5 /* CameraView.swift in Sources */,

--- a/Baggle/Baggle/Core/Common/Const/Image.swift
+++ b/Baggle/Baggle/Core/Common/Const/Image.swift
@@ -10,7 +10,5 @@ import Foundation
 extension Const {
     struct Image {
         static let jpegCompression: CGFloat = 0.9
-        static let feedWidth: CGFloat = 1080
-        static let profileWidth: CGFloat = 320
     }
 }

--- a/Baggle/Baggle/Core/Common/Const/Image.swift
+++ b/Baggle/Baggle/Core/Common/Const/Image.swift
@@ -1,0 +1,16 @@
+//
+//  Image.swift
+//  Baggle
+//
+//  Created by youtak on 2023/08/17.
+//
+
+import Foundation
+
+extension Const {
+    struct Image {
+        static let jpegCompression: CGFloat = 0.9
+        static let feedWidth: CGFloat = 1080
+        static let profileWidth: CGFloat = 320
+    }
+}

--- a/Baggle/Baggle/Core/Common/Extensions/UIImage+.swift
+++ b/Baggle/Baggle/Core/Common/Extensions/UIImage+.swift
@@ -47,3 +47,25 @@ extension UIImage {
         return flippedImage
     }
 }
+
+
+// MARK: - 이미지 다운 스케일링 & 압축
+extension UIImage {
+    func scaleTo(newWidth: CGFloat) -> UIImage {
+        let scale = newWidth / self.size.width
+        let newHeight = self.size.height * scale
+        let newSize = CGSize(width: newWidth, height: newHeight)
+        let renderer = UIGraphicsImageRenderer(size: newSize)
+
+        return renderer.image { _ in
+            self.draw(in: CGRect(origin: .zero, size: newSize))
+        }
+    }
+    
+    func compress(width: CGFloat) -> UIImage {
+        let resizedImage = scaleTo(newWidth: width)
+        resizedImage.jpegData(compressionQuality: 0.9)
+
+        return resizedImage
+    }
+}

--- a/Baggle/Baggle/Core/Common/Extensions/UIImage/ImageSizeType.swift
+++ b/Baggle/Baggle/Core/Common/Extensions/UIImage/ImageSizeType.swift
@@ -1,0 +1,24 @@
+//
+//  ImageSizeType.swift
+//  Baggle
+//
+//  Created by youtak on 2023/08/17.
+//
+
+import SwiftUI
+
+enum ImageSizeType {
+    case small
+    case medium
+    case large
+}
+
+extension ImageSizeType {
+    var size: CGFloat {
+        switch self {
+        case .small: return 320
+        case .medium: return 640
+        case .large: return 1080
+        }
+    }
+}

--- a/Baggle/Baggle/Core/Common/Extensions/UIImage/UIImage+.swift
+++ b/Baggle/Baggle/Core/Common/Extensions/UIImage/UIImage+.swift
@@ -64,8 +64,10 @@ extension UIImage {
     
     func compress(width: CGFloat) -> UIImage {
         let resizedImage = scaleTo(newWidth: width)
-        resizedImage.jpegData(compressionQuality: 0.9)
-
         return resizedImage
+    }
+    
+    func compress(imageSize: ImageSizeType) -> UIImage {
+        return compress(width: imageSize.size)
     }
 }

--- a/Baggle/Baggle/Core/Models/Alert/Camera/AlertCameraType.swift
+++ b/Baggle/Baggle/Core/Models/Alert/Camera/AlertCameraType.swift
@@ -8,7 +8,11 @@
 import Foundation
 
 enum AlertCameraType: Equatable {
+    // Camera
     case cameraConfigureError
+    case noResultImage
+    case compressionError
+    // Network
     case invalidAuthorizationTime
     case notFound
     case alreadyUpload
@@ -21,6 +25,8 @@ extension AlertCameraType {
     var title: String {
         switch self {
         case .cameraConfigureError: return "카메라 설정 에러"
+        case .noResultImage: return "이미지 인식 실패"
+        case .compressionError: return "이미지 압축 실패"
         case .invalidAuthorizationTime: return "인증 시간 경과"
         case .notFound: return "모임 참가자가 없어요"
         case .alreadyUpload: return "피드 인증 완료"
@@ -32,6 +38,8 @@ extension AlertCameraType {
     var description: String {
         switch self {
         case .cameraConfigureError: return "카메라를 초기화하는데 에러가 발생했어요. 카메라를 다시 실행해주세요."
+        case .noResultImage: return "재촬영해주세요."
+        case .compressionError: return "다시 업로드해주세요. 계속 에러가 발생하면 재촬영해주세요."
         case .invalidAuthorizationTime: return "인증 시간이 지났어요."
         case .notFound: return "서버에서 유저 정보를 찾을 수 없어요."
         case .alreadyUpload: return "이미 인증을 완료했어요"
@@ -43,6 +51,8 @@ extension AlertCameraType {
     var buttonTitle: String {
         switch self {
         case .cameraConfigureError: return "돌아가기"
+        case .noResultImage: return "재촬영"
+        case .compressionError: return "확인"
         case .invalidAuthorizationTime: return "돌아가기"
         case .notFound: return "확인"
         case .alreadyUpload: return "돌아가기"

--- a/Baggle/Baggle/Core/Models/Network/Feed/FeedPhotoRequestModel.swift
+++ b/Baggle/Baggle/Core/Models/Network/Feed/FeedPhotoRequestModel.swift
@@ -5,9 +5,28 @@
 //  Created by youtak on 2023/08/15.
 //
 
-import Foundation
+import SwiftUI
 
 struct FeedPhotoRequestModel: Encodable {
     let memberInfo: FeedMemberInfoRequestModel
     let feedImage: Data
+}
+
+extension FeedPhotoRequestModel {
+    init?(memberID: Int, time: Date, feedImage: UIImage) {
+        guard let compressedImage = feedImage
+            .compress(width: 1080)
+            .jpegData(compressionQuality: Const.Image.jpegCompression)
+        else {
+            return nil
+        }
+        
+        self.init(
+            memberInfo: FeedMemberInfoRequestModel(
+                memberID: memberID,
+                authorizationTime: time
+            ),
+            feedImage: compressedImage
+        )
+    }
 }

--- a/Baggle/Baggle/Core/Models/Network/Feed/FeedPhotoRequestModel.swift
+++ b/Baggle/Baggle/Core/Models/Network/Feed/FeedPhotoRequestModel.swift
@@ -15,7 +15,7 @@ struct FeedPhotoRequestModel: Encodable {
 extension FeedPhotoRequestModel {
     init?(memberID: Int, time: Date, feedImage: UIImage) {
         guard let compressedImage = feedImage
-            .compress(width: 1080)
+            .compress(imageSize: .large)
             .jpegData(compressionQuality: Const.Image.jpegCompression)
         else {
             return nil

--- a/Baggle/Baggle/Core/Models/SignUp/ProfileImageModel.swift
+++ b/Baggle/Baggle/Core/Models/SignUp/ProfileImageModel.swift
@@ -19,7 +19,7 @@ struct ProfileImageModel: Transferable {
             guard let uiImage = UIImage(data: data) else {
                 throw TransferError.importFailed
             }
-            let compressedImage = uiImage.compress(width: Const.Image.feedWidth)
+            let compressedImage = uiImage.compress(imageSize: .small)
             return ProfileImageModel(image: compressedImage)
         }
     }

--- a/Baggle/Baggle/Core/Models/SignUp/ProfileImageModel.swift
+++ b/Baggle/Baggle/Core/Models/SignUp/ProfileImageModel.swift
@@ -19,8 +19,8 @@ struct ProfileImageModel: Transferable {
             guard let uiImage = UIImage(data: data) else {
                 throw TransferError.importFailed
             }
-
-            return ProfileImageModel(image: uiImage)
+            let compressedImage = uiImage.compress(width: Const.Image.feedWidth)
+            return ProfileImageModel(image: compressedImage)
         }
     }
 }

--- a/Baggle/Baggle/Features/Camera/CameraFeature.swift
+++ b/Baggle/Baggle/Features/Camera/CameraFeature.swift
@@ -178,19 +178,19 @@ struct CameraFeature: ReducerProtocol {
             case .uploadButtonTapped:
                 state.isUploading = true
                 
-                guard let resultImage = state.resultImage,
-                      let imageData = resultImage.jpegData(compressionQuality: 0.9)
-                else {
+                guard let resultImage = state.resultImage else {
+                    // 이미지 없음
                     return .none
                 }
                 
-                let feedPhotoRequestModel = FeedPhotoRequestModel(
-                    memberInfo: FeedMemberInfoRequestModel(
-                        memberID: 22,
-                        authorizationTime: Date()
-                    ),
-                    feedImage: imageData
-                )
+                guard let feedPhotoRequestModel = FeedPhotoRequestModel(
+                    memberID: 22,
+                    time: Date(),
+                    feedImage: resultImage
+                ) else {
+                    // 압축 실패
+                    return .none
+                }
                 
                 return .run { send in
                     let feedPhotoStatus = await feedPhotoService.upload(feedPhotoRequestModel)

--- a/Baggle/Baggle/Features/Camera/CameraFeature.swift
+++ b/Baggle/Baggle/Features/Camera/CameraFeature.swift
@@ -189,6 +189,7 @@ struct CameraFeature: ReducerProtocol {
                 
                 guard let resultImage = state.resultImage else {
                     // 이미지 없음
+                    state.alertType = .noResultImage
                     return .none
                 }
                 
@@ -197,7 +198,7 @@ struct CameraFeature: ReducerProtocol {
                     time: Date(),
                     feedImage: resultImage
                 ) else {
-                    // 압축 실패
+                    state.alertType = .compressionError
                     return .none
                 }
                 
@@ -278,10 +279,14 @@ struct CameraFeature: ReducerProtocol {
                 switch alertType {
                 case .cameraConfigureError, .invalidAuthorizationTime, .alreadyUpload:
                     return .run { _ in await self.dismiss() }
-                case .notFound, .networkError:
-                    return .none
                 case .userError:
                     return .run { send in await send(.delegate(.moveToLogin)) }
+                case .noResultImage:
+                    state.resultImage = nil
+                    state.isCompleted = false
+                    return .none
+                case .notFound, .networkError, .compressionError:
+                    return .none
                 }
                 
             case .presentBaggleAlert(let isPresented):

--- a/Baggle/Baggle/Features/Login/SignUp/Main/SignUpFeature.swift
+++ b/Baggle/Baggle/Features/Login/SignUp/Main/SignUpFeature.swift
@@ -178,9 +178,8 @@ struct SignUpFeature: ReducerProtocol {
                 return .run { send in await send(.disableButtonChanged) }
 
             case let .successImageChange(image):
-                let compressedImage = image.compress(width: Const.Image.profileWidth)
-                state.imageState = .success(Image(uiImage: compressedImage))
-                state.selectedImage = compressedImage.jpegData(
+                state.imageState = .success(Image(uiImage: image))
+                state.selectedImage = image.jpegData(
                     compressionQuality: Const.Image.jpegCompression
                 )
                 return .run { send in await send(.disableButtonChanged) }

--- a/Baggle/Baggle/Features/Login/SignUp/Main/SignUpFeature.swift
+++ b/Baggle/Baggle/Features/Login/SignUp/Main/SignUpFeature.swift
@@ -178,8 +178,11 @@ struct SignUpFeature: ReducerProtocol {
                 return .run { send in await send(.disableButtonChanged) }
 
             case let .successImageChange(image):
-                state.imageState = .success(Image(uiImage: image).resizable())
-                state.selectedImage = image.jpegData(compressionQuality: 0.5)
+                let compressedImage = image.compress(width: Const.Image.profileWidth)
+                state.imageState = .success(Image(uiImage: compressedImage))
+                state.selectedImage = compressedImage.jpegData(
+                    compressionQuality: Const.Image.jpegCompression
+                )
                 return .run { send in await send(.disableButtonChanged) }
 
             case .failImageChange:


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #23

## 내용
<!--
로직 설명  
--> 
- 서버에 이미지를 보내기 전에 다운 스케일 & 압축합니다. 피드 이미지는 이슈에 나온 것처럼 인스타를 기준으로 다운 스케일링했고, 프로필이미지는 그냥 했습니다. 
  - 프로필 이미지의 경우 width = 320 로 다운 스케일합니다.
  - 피드 이미지의 경우 width = 1080으로 다운 스케일합니다.
- jpeg 압축률 0.9로 압축을 합니다. 사진 찍을 때 압축률 0.9과 1.0은 인간 눈으로 구별 못한다는 얘기를 많이 들어서 화질 손상 없이 압축할 수 있는 0.9로 설정했습니다.
- Const - Image 에 상수들 저장했습니다.
- 이미지 모델 가져오거나, 압축 실패시 Alert 처리해주었습니다.

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
