### PR TITLE
Fix - 푸시알림 userInfo에서 meetingId 분리, 화면 전환 연결

### DIFF
--- a/Baggle/Baggle/Core/Common/Extensions/PostObserverAction.swift
+++ b/Baggle/Baggle/Core/Common/Extensions/PostObserverAction.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 import ComposableArchitecture
 
@@ -24,6 +25,20 @@ extension NSObject {
 }
 
 extension ReducerProtocol {
+    func postObserverAction(
+        _ keyName: Notification.Name,
+        object: Any? = nil,
+        userInfo: [AnyHashable: Any]? = nil
+    ) {
+        NotificationCenter.default.post(
+            name: keyName,
+            object: object,
+            userInfo: userInfo
+        )
+    }
+}
+
+extension View {
     func postObserverAction(
         _ keyName: Notification.Name,
         object: Any? = nil,

--- a/Baggle/Baggle/Core/Common/Foundation/Notification+Name.swift
+++ b/Baggle/Baggle/Core/Common/Foundation/Notification+Name.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 extension Notification.Name {
+    static let skipSplash = Notification.Name(rawValue: "skipSplash")
     static let moveMeetingDetail = Notification.Name(rawValue: "moveMeetingDetail")
     static let refreshMeetingList = Notification.Name("refreshMeetingList")
 }

--- a/Baggle/Baggle/Features/App/AppView.swift
+++ b/Baggle/Baggle/Features/App/AppView.swift
@@ -13,6 +13,7 @@ struct AppView: View {
 
     let store: StoreOf<AppFeature>
 
+    @State var skipSplash: Bool = false
     @State var splashStarted: Bool = false
     @State var splashEnded: Bool = false
 
@@ -50,11 +51,20 @@ struct AppView: View {
             withAnimation {
                 splashStarted = true
             }
-
-            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1) {
+            
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + (skipSplash ? 0 : 1)) {
                 withAnimation {
                     splashEnded = true
                 }
+            }
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(for: .skipSplash)
+        ) { noti in
+            skipSplash = true
+            splashEnded = true
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.2) {
+                postObserverAction(.moveMeetingDetail, object: noti.object)
             }
         }
     }

--- a/Baggle/Baggle/Features/Tab/Home/HomeView.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeView.swift
@@ -67,7 +67,6 @@ struct HomeView: View {
             })
             .onReceive(NotificationCenter.default.publisher(for: .moveMeetingDetail),
                        perform: { noti in
-                // noti로부터 id 값 받아서 넣기
                 if let id = noti.object as? Int {
                     viewStore.send(.pushToMeetingDetail(id))
                 }

--- a/Baggle/Baggle/Sources/AppDelegate.swift
+++ b/Baggle/Baggle/Sources/AppDelegate.swift
@@ -71,7 +71,10 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     ) {
         let userInfo = response.notification.request.content.userInfo
         Messaging.messaging().appDidReceiveMessage(userInfo)
-        self.postObserverAction(.moveMeetingDetail, object: 1)
+        
+        if let meetingId: Int = Int(userInfo["meetingId"] as? String ?? "") {
+            postObserverAction(.moveMeetingDetail, object: meetingId)
+        }
 
         let applicationState = UIApplication.shared.applicationState
         print("didReceive - applicationState: \(applicationState)")

--- a/Baggle/Baggle/Sources/SceneDelegate.swift
+++ b/Baggle/Baggle/Sources/SceneDelegate.swift
@@ -19,9 +19,8 @@ class SceneDelegate: NSObject, UIWindowSceneDelegate {
         if let notification = connectionOptions.notificationResponse {
             let userInfo = notification.notification.request.content.userInfo
             if let meetingId: Int = Int(userInfo["meetingId"] as? String ?? "") {
-                // 최초 진입시 스플래시 애니메이션 시간 + 0.4
-                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.4) {
-                    self.postObserverAction(.moveMeetingDetail, object: meetingId)
+                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.2) {
+                    self.postObserverAction(.skipSplash, object: meetingId)
                 }
             }
         }

--- a/Baggle/Baggle/Sources/SceneDelegate.swift
+++ b/Baggle/Baggle/Sources/SceneDelegate.swift
@@ -18,9 +18,11 @@ class SceneDelegate: NSObject, UIWindowSceneDelegate {
     ) {
         if let notification = connectionOptions.notificationResponse {
             let userInfo = notification.notification.request.content.userInfo
-            print("userInfo: \(userInfo)")
-            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.2) {
-                self.postObserverAction(.moveMeetingDetail, object: 111)
+            if let meetingId: Int = Int(userInfo["meetingId"] as? String ?? "") {
+                // 최초 진입시 스플래시 애니메이션 시간 + 0.4
+                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.4) {
+                    self.postObserverAction(.moveMeetingDetail, object: meetingId)
+                }
             }
         }
     }


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
close #183 

## 내용
<!--
로직 설명  
--> 

- 푸시알림 userInfo에서 meetingId 분리
- 최초 진입시 스플래시 애니메이션 시간 때문에 noti 전달 안되는 문제 해결 (스플래시 애니메이션 시간 + 0.4)

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 
meetingId 겟
![스크린샷 2023-08-18 오후 12 25 30](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/f0800bf9-619e-433f-8a3a-8aa5d0150b64)

에 .. 얼레벌레 확인하다가 영상을 못찍었습니다.. 모임 상세로 진입해서 모임 상세 조회 통신하는 것까지 확인 했습니다

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
