### PR TITLE
Fix #168 - TimeZone KST로 변경

### DIFF
--- a/Baggle/Baggle/Core/Common/Extensions/Date/Date+.swift
+++ b/Baggle/Baggle/Core/Common/Extensions/Date/Date+.swift
@@ -105,9 +105,9 @@ extension Date {
     func toString(format: String) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = format
+        dateFormatter.timeZone = TimeZone(abbreviation: "KST")
         dateFormatter.calendar = Calendar(identifier: .iso8601)
         dateFormatter.locale = Locale(identifier: "ko_kr")
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
         return dateFormatter.string(from: self)
     }
 
@@ -151,7 +151,8 @@ extension Date {
         let calendar = Calendar.current
         let component = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: Date())
         // swiftlint:disable:next force_unwrapping
-        return calendar.date(from: component)!
+        let now = calendar.date(from: component)!
+        return now
     }
     
     // n 시간 이후 생성

--- a/Baggle/Baggle/Core/Common/Extensions/Date/DateFormatter+.swift
+++ b/Baggle/Baggle/Core/Common/Extensions/Date/DateFormatter+.swift
@@ -12,7 +12,7 @@ extension DateFormatter {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
         formatter.calendar = Calendar(identifier: .iso8601)
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.timeZone = TimeZone(abbreviation: "KST")
         formatter.locale = Locale(identifier: "ko_kr")
         return formatter
     }()

--- a/Baggle/Baggle/DesignSystem/View/Date/Picker/BaggleDatePickerView.swift
+++ b/Baggle/Baggle/DesignSystem/View/Date/Picker/BaggleDatePickerView.swift
@@ -13,18 +13,18 @@ struct BaggleDatePickerView: View {
 
     @Binding var date: Date
 
-    let tenYearsFromNow = Date().addingTimeInterval(10 * 365 * 24 * 60 * 60)
+    let tenYearsFromNow = Date.now().addingTimeInterval(10 * 365 * 24 * 60 * 60)
 
     var body: some View {
         DatePicker(
             "",
             selection: $date,
-            in: Date()...tenYearsFromNow,
+            in: Date.now()...tenYearsFromNow,
             displayedComponents: .date
         )
         .labelsHidden()
         .datePickerStyle(.wheel)
-        .environment(\.locale, Locale.init(identifier: "KO"))
+        .environment(\.locale, Locale.init(identifier: "ko_kr"))
     }
 }
 

--- a/Baggle/Baggle/DesignSystem/View/Date/Picker/BaggleTimePickerView.swift
+++ b/Baggle/Baggle/DesignSystem/View/Date/Picker/BaggleTimePickerView.swift
@@ -24,7 +24,7 @@ struct BaggleTimePickerView: View {
         }
         .labelsHidden()
         .datePickerStyle(.wheel)
-        .environment(\.locale, Locale.init(identifier: "KO"))
+        .environment(\.locale, Locale.init(identifier: "ko_kr"))
     }
 }
 


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
close #168 

## 내용
<!--
로직 설명  
--> 
- Locale identifier `ko_kr` 통일
- DateFormatter+(baggleFormat), Date+ TimeZone `KST` 통일
   - 서버에서 받는 Date 타입을 전부 KST로 통일해줬습니다.
   - Date+의 now()나 내부 로직에서는 UTC 시간대로 동작하며, 모든 뷰에 보여지는 시간은 toString을 통해 KST로 변환해서 보여지게 합니다.
   - 서버에 date를 전달할때는 기존처럼 KST로 변환해서 전달합니다

이때 서버에서 받는 Date 타입을 baggleFormat을 통해 KST로 변경해주면 아래처럼 -9시간이 됩니다.
내가 받는 date 타입은 KST 시간대이니 일단 받아오고, swift 내부에서는 UTC 시간대를 사용하니 디코딩 과정에서 KST를 UTC로 자동 변경해주는 것 같습니다.. (추측입니다..)
![스크린샷 2023-08-21 오후 7 23 15](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/631428d6-7db0-43d2-bc79-33c3106fda59)

내부 로직에서 많은 부분이 UTC 시간대를 사용하고 있기 때문에 그냥 받아오는 것을 디코딩 과정에서 UTC로 받아서 활용하고,
문자로 보여질때만 일괄적으로 KST로 변환하는 지금 방식도 괜찮지 않을까 싶습니다

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 
![ezgif com-resize (38)](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/78c3527c-e0ea-4f11-b36c-9e8551f81210)


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

첨부한 gif에서 시간대가 맞는지 확인부탁드립니다
- 실행 당시 시각: 8/21 19:15
- 생성시 자동 할당된 시각: 8/21 21:15
- 생성한 모임 시각(모임 생성 완료, 홈 뷰): 9/1 9:00

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
