### PR TITLE
Fix - 모임 참여 에러 분기처리, 참여 성공시 홈 업데이트

### DIFF
--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -153,6 +153,8 @@
 		2B39F21C2A738BB100E034A3 /* SendInvitation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B39F21B2A738BB100E034A3 /* SendInvitation.swift */; };
 		2B3B64952A8014540082A05F /* FeedListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3B64942A8014540082A05F /* FeedListCell.swift */; };
 		2B409D7C2A80BE840051A3BC /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B409D7B2A80BE840051A3BC /* Font+.swift */; };
+		2B437FBA2A93B64C004DC68E /* AlertJoinMeetingType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B437FB92A93B64C004DC68E /* AlertJoinMeetingType.swift */; };
+		2B437FBD2A93BE37004DC68E /* AlertType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B437FBC2A93BE37004DC68E /* AlertType.swift */; };
 		2B45F2212A7B634400874783 /* MeetingDeleteType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B45F2202A7B634400874783 /* MeetingDeleteType.swift */; };
 		2B5BE6B22A77A40900F25474 /* MockUpMeetingDetailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5BE6B12A77A40900F25474 /* MockUpMeetingDetailService.swift */; };
 		2B5CF2682A6EC889004D3033 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5CF2672A6EC889004D3033 /* View+.swift */; };
@@ -378,6 +380,8 @@
 		2B39F21B2A738BB100E034A3 /* SendInvitation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendInvitation.swift; sourceTree = "<group>"; };
 		2B3B64942A8014540082A05F /* FeedListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedListCell.swift; sourceTree = "<group>"; };
 		2B409D7B2A80BE840051A3BC /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
+		2B437FB92A93B64C004DC68E /* AlertJoinMeetingType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertJoinMeetingType.swift; sourceTree = "<group>"; };
+		2B437FBC2A93BE37004DC68E /* AlertType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertType.swift; sourceTree = "<group>"; };
 		2B45F2202A7B634400874783 /* MeetingDeleteType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDeleteType.swift; sourceTree = "<group>"; };
 		2B5BE6B12A77A40900F25474 /* MockUpMeetingDetailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUpMeetingDetailService.swift; sourceTree = "<group>"; };
 		2B5CF2672A6EC889004D3033 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
@@ -1183,6 +1187,7 @@
 			isa = PBXGroup;
 			children = (
 				14EA20B52A8DBC4C005C1289 /* Common */,
+				2B437FBB2A93B693004DC68E /* JoinMeeting */,
 				14EA20AF2A8DAB13005C1289 /* CreateMeeting */,
 				14EA20B42A8DB65F005C1289 /* MeetingDetail */,
 				14EA20BA2A8DCBB9005C1289 /* Camera */,
@@ -1211,6 +1216,7 @@
 			isa = PBXGroup;
 			children = (
 				14EA20B62A8DBC52005C1289 /* AlertButtonType.swift */,
+				2B437FBC2A93BE37004DC68E /* AlertType.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1338,6 +1344,14 @@
 				2B7EC32E2A8251DC00D78141 /* HomeStatus.swift */,
 			);
 			path = Common;
+			sourceTree = "<group>";
+		};
+		2B437FBB2A93B693004DC68E /* JoinMeeting */ = {
+			isa = PBXGroup;
+			children = (
+				2B437FB92A93B64C004DC68E /* AlertJoinMeetingType.swift */,
+			);
+			path = JoinMeeting;
 			sourceTree = "<group>";
 		};
 		2B5BE6B02A77A3F600F25474 /* MeetingDetail */ = {
@@ -1734,6 +1748,7 @@
 				145210892A8E2D7800150C57 /* ImageSizeType.swift in Sources */,
 				146237462A877CFB00FBE121 /* PlatformLogoView.swift in Sources */,
 				2B84696D2A6E7AE200D75D32 /* ShadeView.swift in Sources */,
+				2B437FBA2A93B64C004DC68E /* AlertJoinMeetingType.swift in Sources */,
 				2BABCB282A76D08400AFECA3 /* PostObserverAction.swift in Sources */,
 				1432BE6D2A682FCB0098AAA9 /* HomeView.swift in Sources */,
 				2B409D7C2A80BE840051A3BC /* Font+.swift in Sources */,
@@ -1828,6 +1843,7 @@
 				146C51F02A79429E00FF3142 /* SelectDateView.swift in Sources */,
 				14EA20BC2A8DCBCD005C1289 /* AlertCameraType.swift in Sources */,
 				14CF68EE2A847C5C00E457DF /* LoginPlatform.swift in Sources */,
+				2B437FBD2A93BE37004DC68E /* AlertType.swift in Sources */,
 				2BA760B72A81DD4A0089878D /* MeetingStatus.swift in Sources */,
 				2BE5299E2A7D697800A53779 /* MeetingListCell.swift in Sources */,
 				14B7A0412A753D4800B8E202 /* SignUpService.swift in Sources */,

--- a/Baggle/Baggle/Core/Common/Extensions/Date/Date+.swift
+++ b/Baggle/Baggle/Core/Common/Extensions/Date/Date+.swift
@@ -267,7 +267,7 @@ extension Date {
     /// result: true
 
     func isUpcomingDays(_ date: Date) -> Bool {
-        var calendar = Calendar.current
+        let calendar = Calendar.current
         let currentDate = calendar.startOfDay(for: date)
         let comparisonResult = calendar.compare(self, to: currentDate, toGranularity: .day)
 
@@ -353,9 +353,12 @@ extension Date {
 
 #if DEBUG
 extension Date {
+    // swiftlint:disable:next line_length
     static func createDate(_ year: Int, _ month: Int, _ day: Int, _ hour: Int, _ minute: Int) -> Date {
+        // swiftlint:disable:next line_length
         let targetDateComponents = DateComponents(year: year, month: month, day: day, hour: hour, minute: minute)
         let targetDate = Calendar.current.date(from: targetDateComponents)
+        // swiftlint:disable:next force_unwrapping
         return targetDate!
     }
 }

--- a/Baggle/Baggle/Core/Common/Foundation/KeychainManager.swift
+++ b/Baggle/Baggle/Core/Common/Foundation/KeychainManager.swift
@@ -45,11 +45,15 @@ class KeychainManager {
                            kSecReturnAttributes: true,
                                  kSecReturnData: true]
         var item: CFTypeRef?
+        // swiftlint:disable:next line_length
         if SecItemCopyMatching(query as CFDictionary, &item) != errSecSuccess { throw KeyChainError.read }
         
         guard let existingItem = item as? [String: Any],
               let data = existingItem[kSecAttrGeneric as String] as? Data,
-              let user = try? JSONDecoder().decode(UserToken.self, from: data) else { throw KeyChainError.read }
+              let user = try? JSONDecoder().decode(UserToken.self, from: data)
+        else {
+            throw KeyChainError.read
+        }
         
         return user
     }

--- a/Baggle/Baggle/Core/Common/Foundation/SafariWebView.swift
+++ b/Baggle/Baggle/Core/Common/Foundation/SafariWebView.swift
@@ -16,6 +16,5 @@ struct SafariWebView: UIViewControllerRepresentable {
     }
     
     func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {
-        
     }
 }

--- a/Baggle/Baggle/Core/Models/Alert/Camera/AlertCameraType.swift
+++ b/Baggle/Baggle/Core/Models/Alert/Camera/AlertCameraType.swift
@@ -20,7 +20,9 @@ enum AlertCameraType: Equatable {
     case userError // 유저 에러
 }
 
-extension AlertCameraType {
+extension AlertCameraType: AlertType {
+    
+    var buttonType: AlertButtonType { return .one }
     
     var title: String {
         switch self {

--- a/Baggle/Baggle/Core/Models/Alert/Common/AlertType.swift
+++ b/Baggle/Baggle/Core/Models/Alert/Common/AlertType.swift
@@ -1,0 +1,15 @@
+//
+//  AlertType.swift
+//  Baggle
+//
+//  Created by 양수빈 on 2023/08/22.
+//
+
+import Foundation
+
+protocol AlertType {
+    var buttonType: AlertButtonType { get }
+    var title: String { get }
+    var description: String { get }
+    var buttonTitle: String { get }
+}

--- a/Baggle/Baggle/Core/Models/Alert/CreateMeeting/AlertCreateMeetingType.swift
+++ b/Baggle/Baggle/Core/Models/Alert/CreateMeeting/AlertCreateMeetingType.swift
@@ -15,7 +15,9 @@ enum AlertCreateMeetingType: Equatable {
     case requestModelError // 모델 생성 에러
 }
 
-extension AlertCreateMeetingType {
+extension AlertCreateMeetingType: AlertType {
+    
+    var buttonType: AlertButtonType { return .one }
 
     var title: String {
         switch self {

--- a/Baggle/Baggle/Core/Models/Alert/Emergency/AlertEmergencyType.swift
+++ b/Baggle/Baggle/Core/Models/Alert/Emergency/AlertEmergencyType.swift
@@ -15,7 +15,9 @@ enum AlertEmergencyType: Equatable {
     case userError // 유저 에러
 }
 
-extension AlertEmergencyType {
+extension AlertEmergencyType: AlertType {
+    
+    var buttonType: AlertButtonType { return .one }
     
     var title: String {
         switch self {

--- a/Baggle/Baggle/Core/Models/Alert/JoinMeeting/AlertJoinMeetingType.swift
+++ b/Baggle/Baggle/Core/Models/Alert/JoinMeeting/AlertJoinMeetingType.swift
@@ -1,0 +1,50 @@
+//
+//  AlertJoinMeetingType.swift
+//  Baggle
+//
+//  Created by 양수빈 on 2023/08/22.
+//
+
+import Foundation
+
+
+enum AlertJoinMeetingType: Equatable {
+    case expired
+    case overlap
+    case exceedMemberCount
+}
+
+extension AlertJoinMeetingType: AlertType {
+    var buttonType: AlertButtonType {
+        switch self {
+        case .expired, .overlap, .exceedMemberCount:
+            return .one
+        }
+    }
+    
+    var title: String {
+        switch self {
+        case .expired:
+            return "이미 만료된 방이에요!"
+        case .overlap:
+            return "기존 모임 시간과 중복됩니다."
+        case .exceedMemberCount:
+            return "참여 가능한 인원을 초과했어요!"
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .expired:
+            return "약속 1시간 전까지만 입장이 가능해요."
+        case .overlap:
+            return "약속 2시간 전후로 이미 모임이 존재합니다."
+        case .exceedMemberCount:
+            return "참여 가능한 인원은 최대 6명입니다."
+        }
+    }
+    
+    var buttonTitle: String {
+        return "확인"
+    }
+}

--- a/Baggle/Baggle/Core/Models/Alert/MeetingDetail/AlertMeetingDetailType.swift
+++ b/Baggle/Baggle/Core/Models/Alert/MeetingDetail/AlertMeetingDetailType.swift
@@ -17,7 +17,7 @@ enum AlertMeetingDetailType: Equatable {
     case delete
 }
 
-extension AlertMeetingDetailType {
+extension AlertMeetingDetailType: AlertType {
 
     var buttonType: AlertButtonType {
         switch self {

--- a/Baggle/Baggle/Core/Models/JoinMeeting/JoinMeetingStatus.swift
+++ b/Baggle/Baggle/Core/Models/JoinMeeting/JoinMeetingStatus.swift
@@ -7,10 +7,9 @@
 
 import Foundation
 
-// TODO: - 모임 참여 불가(2시간 전후 일정 존재, 모임 인원 초과) 추가
 enum JoinMeetingStatus: Equatable {
     case enable(JoinMeeting)
-    case expired
+    case expired(APIError)
     case joined
     case fail(APIError)
 }

--- a/Baggle/Baggle/Core/Models/Network/Common/JSONNULL.swift
+++ b/Baggle/Baggle/Core/Models/Network/Common/JSONNULL.swift
@@ -22,7 +22,13 @@ class JSONNull: Codable, Hashable {
     public required init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         if !container.decodeNil() {
-            throw DecodingError.typeMismatch(JSONNull.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Wrong type for JSONNull"))
+            throw DecodingError.typeMismatch(
+                JSONNull.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Wrong type for JSONNull"
+                )
+            )
         }
     }
 

--- a/Baggle/Baggle/Core/Models/User/UserToken.swift
+++ b/Baggle/Baggle/Core/Models/User/UserToken.swift
@@ -8,9 +8,4 @@
 struct UserToken: Codable {
     var accessToken: String
     var refreshToken: String
-    
-    init(accessToken: String, refreshToken: String) {
-        self.accessToken = accessToken
-        self.refreshToken = refreshToken
-    }
 }

--- a/Baggle/Baggle/Core/Services/Common/NetworkService.swift
+++ b/Baggle/Baggle/Core/Services/Common/NetworkService.swift
@@ -102,15 +102,19 @@ extension NetworkService {
     private func handleError400(statusCode: Int, message: String) -> APIError {
         switch statusCode {
         case 400:
+            if message == "모임 2시간 전후 일정이 존재합니다." {
+                return APIError.overlapMeetingTime
+            }
             return APIError.badRequest
         case 401:
             return APIError.unauthorized
         case 403:
             if message == "모임은 하루에 2개까지만 생성 가능합니다." {
                 return APIError.duplicatedMeeting
-            } else {
-                return APIError.forbidden
+            } else if message == "모임 인원이 초과됐습니다." {
+                return APIError.exceedMemberCount
             }
+            return APIError.forbidden
         case 404:
             return APIError.notFound
         case 409:
@@ -118,9 +122,8 @@ extension NetworkService {
                 return APIError.duplicatedNickname
             } else if message == "이미 존재하는 참가자입니다." {
                 return APIError.duplicatedJoinMeeting
-            } else {
-                return APIError.duplicatedUser
             }
+            return APIError.duplicatedUser
         default:
             return APIError.network
         }

--- a/Baggle/Baggle/Core/Services/Error/APIError.swift
+++ b/Baggle/Baggle/Core/Services/Error/APIError.swift
@@ -9,9 +9,11 @@ import Foundation
 
 enum APIError: Error, Equatable {
     case badRequest // 400
-    case duplicatedMeeting
+    case overlapMeetingTime // 400, 모임 2시간 전후 일정 존재
     case unauthorized // 401, 토큰 에러
-    case forbidden // 403 리소스 접근 제한
+    case duplicatedMeeting // 403, 모임 생성 최대 개수 초과
+    case exceedMemberCount // 403, 모임 참여 가능 인원 초과
+    case forbidden // 403, 리소스 접근 제한
     case notFound // 404, 리소스 또는 유저 정보 없음
     case duplicatedUser // 409, 이미 존재하는 회원
     case duplicatedNickname // 409, 닉네임 중복
@@ -29,8 +31,10 @@ extension APIError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .badRequest: return "400 에러"
-        case .duplicatedMeeting: return "모임 2시간 전후 생성 불가"
+        case .overlapMeetingTime: return "모임 2시간 전후 일정 존재"
         case .unauthorized: return "401 에러"
+        case .duplicatedMeeting: return "모임 2시간 전후 생성 불가"
+        case .exceedMemberCount: return "모임 참여 가능 인원 초과"
         case .forbidden: return "403 에러"
         case .notFound: return "404 에러"
         case .duplicatedUser: return "409 에러"

--- a/Baggle/Baggle/Core/Services/Home/HomeService.swift
+++ b/Baggle/Baggle/Core/Services/Home/HomeService.swift
@@ -48,6 +48,7 @@ struct MockUpMeetingService {
         })
     }
 
+    // swiftlint:disable:next function_body_length
     private func makeMockMeetingList(_ type: MeetingStatus) -> [Meeting] {
         let progress = [
             Meeting(

--- a/Baggle/Baggle/Core/Services/JoinMeeting/JoinMeetingService.swift
+++ b/Baggle/Baggle/Core/Services/JoinMeeting/JoinMeetingService.swift
@@ -36,7 +36,7 @@ extension JoinMeetingService: DependencyKey {
             if error == .duplicatedJoinMeeting {
                 return JoinMeetingStatus.joined
             } else {
-                return JoinMeetingStatus.expired
+                return JoinMeetingStatus.expired(error)
             }
         }
     } postJoinMeeting: { meetingID in

--- a/Baggle/Baggle/Core/Services/Meeting/MeetingDetail/MockUp/MockUpMeetingDetailService.swift
+++ b/Baggle/Baggle/Core/Services/Meeting/MeetingDetail/MockUp/MockUpMeetingDetailService.swift
@@ -111,6 +111,7 @@ extension MockUpMeetingAPI {
         })
     }
     
+    // swiftlint:disable:next function_body_length
     private func meetingDetailCompleted() -> MeetingDetail {
         MeetingDetail(
             id: 0,

--- a/Baggle/Baggle/Features/JoinMeeting/JoinMeetingFeature.swift
+++ b/Baggle/Baggle/Features/JoinMeeting/JoinMeetingFeature.swift
@@ -12,21 +12,33 @@ import ComposableArchitecture
 struct JoinMeetingFeature: ReducerProtocol {
 
     struct State: Equatable {
-        // MARK: - Scope State
+        
+        // joinMeeting
         var meetingId: Int
         var joinMeeingStatus: JoinMeetingStatus
-        var isAlertPresented: Bool = false
+        
+        // alert
+        var alertType: AlertJoinMeetingType?
     }
 
     enum Action: Equatable {
-        // MARK: - Scope Action
         
+        // view
         case onAppear
+        
+        // button
         case exitButtonTapped
         case joinButtonTapped
+        
+        // response
         case joinSuccess
         case joinFailed
-        case presentAlert
+        
+        // alert
+        case presentAlert(Bool)
+        case alertButtonTapped
+        
+        // meetingDetail
         case moveToMeetingDetail
     }
 
@@ -43,8 +55,16 @@ struct JoinMeetingFeature: ReducerProtocol {
 
             switch action {
             case .onAppear:
-                if state.joinMeeingStatus == .expired {
-                    return .run { send in await send(.presentAlert) }
+                if case let .expired(error) = state.joinMeeingStatus {
+                    switch error {
+                    case .overlapMeetingTime:
+                        state.alertType = .overlap
+                    case .exceedMemberCount:
+                        state.alertType = .exceedMemberCount
+                    default:
+                        state.alertType = .expired
+                    }
+                    return .run { send in await send(.presentAlert(true)) }
                 }
                 return .none
                 
@@ -76,8 +96,16 @@ struct JoinMeetingFeature: ReducerProtocol {
                     }
                 }
                 
-            case .presentAlert:
-                state.isAlertPresented.toggle()
+            case .presentAlert(let isPresented):
+                if !isPresented {
+                    state.alertType = nil
+                }
+                return .none
+                
+            case .alertButtonTapped:
+                if let alertType = state.alertType {
+                    state.alertType = nil
+                }
                 return .none
             }
         }

--- a/Baggle/Baggle/Features/JoinMeeting/JoinMeetingFeature.swift
+++ b/Baggle/Baggle/Features/JoinMeeting/JoinMeetingFeature.swift
@@ -103,9 +103,7 @@ struct JoinMeetingFeature: ReducerProtocol {
                 return .none
                 
             case .alertButtonTapped:
-                if let alertType = state.alertType {
-                    state.alertType = nil
-                }
+                if state.alertType != nil { state.alertType = nil }
                 return .none
             }
         }

--- a/Baggle/Baggle/Features/JoinMeeting/JoinMeetingView.swift
+++ b/Baggle/Baggle/Features/JoinMeeting/JoinMeetingView.swift
@@ -39,7 +39,9 @@ struct JoinMeetingView: View {
                             .padding(.bottom, 16)
                     }
                 } else {
-                    baggleAlert(viewStore: viewStore)
+                    if let alertType = viewStore.alertType {
+                        baggleAlert(viewStore: viewStore, alertType: alertType)
+                    }
                 }
             }
             .onAppear { viewStore.send(.onAppear) }
@@ -124,15 +126,15 @@ extension JoinMeetingView {
         }
     }
     
-    func baggleAlert(viewStore: Viewstore) -> some View {
+    func baggleAlert(viewStore: Viewstore, alertType: AlertType) -> some View {
         BaggleAlertOneButton(
             isPresented: Binding(
-                get: { viewStore.isAlertPresented },
-                set: { _ in viewStore.send(.presentAlert) }
+                get: { viewStore.alertType != nil },
+                set: { viewStore.send(.presentAlert($0)) }
             ),
-            title: "이미 만료된 방이에요!",
-            description: "약속 1시간 전까지만 입장이 가능해요.",
-            buttonTitle: "확인") {
+            title: alertType.title,
+            description: alertType.description,
+            buttonTitle: alertType.buttonTitle) {
                 viewStore.send(.exitButtonTapped)
             }
     }
@@ -142,7 +144,9 @@ struct JoinMeetingView_Previews: PreviewProvider {
     static var previews: some View {
         JoinMeetingView(
             store: Store(
-                initialState: JoinMeetingFeature.State(meetingId: 100, joinMeeingStatus: .expired),
+                initialState: JoinMeetingFeature.State(
+                    meetingId: 100,
+                    joinMeeingStatus: .expired(.overlapMeetingTime)),
                 reducer: JoinMeetingFeature()
             )
         )

--- a/Baggle/Baggle/Features/Tab/Home/HomeView.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeView.swift
@@ -72,6 +72,7 @@ struct HomeView: View {
             .onReceive(NotificationCenter.default.publisher(for: .moveMeetingDetail),
                        perform: { noti in
                 if let id = noti.object as? Int {
+                    viewStore.send(.refreshMeetingList)
                     viewStore.send(.pushToMeetingDetail(id))
                 }
             })


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
close #196 
close #197 

## 내용
<!--
로직 설명  
--> 

1. 모임 참여 에러 분기처리
   - 기존에 있는 '만료된 경우' 외에 '참여 가능 인원 초과', '모임 시간 중복' 에러 추가했습니다
   - AlertType 프로토콜을 만들어서 적용했습니다
2. 자잘하게 swiftlint 반영해서 코드 수정
3. 모임 참여 성공시 홈 업데이트
   - 모임 참여 성공시 모임 상세로 가게 하는 노티 받았을때 처리하도록 추가했습니다.

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

**기존 모임이랑 중복 에러**

https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/d4c31e15-6faa-438d-aa79-3ecb46f73d7e 

**모임 참여 성공시 홈 업데이트**

https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/680c470b-7f34-4d3d-92b3-d89ae03a4dbe


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
자잘하게 swiftlint 반영해서 수정하다보니까 file changed가 많아졌습니다.. 
AlertJoinMeetingType, APIError, JoinMeetingView, JoinMeetingFeature 등 alert랑 에러 위주로 봐주시면 됩니다

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
