### PR TITLE
Fix - 프로필 찌그러지는 문제, 메모 기본 문구 안뜨는 문제 해결

### DIFF
--- a/Baggle/Baggle/Core/Models/Network/MeetingDetail/MeetingDetailEntity.swift
+++ b/Baggle/Baggle/Core/Models/Network/MeetingDetail/MeetingDetailEntity.swift
@@ -26,21 +26,21 @@ struct MeetingDetailEntity: Codable {
 extension MeetingDetailEntity {
     func toDomain(username: String) -> MeetingDetail {
         MeetingDetail(
-            id: self.meetingID,
-            name: self.title,
-            place: self.place,
-            date: self.meetingTime.koreanDate(),
-            time: self.meetingTime.hourMinute(),
-            memo: self.memo,
-            members: self.members.map { $0.memberDomain(meetingConfirmed: isMeetingConfirmed()) },
+            id: meetingID,
+            name: title,
+            place: place,
+            date: meetingTime.koreanDate(),
+            time: meetingTime.hourMinute(),
+            memo: (memo ?? "").isEmpty ? nil : memo,
+            members: members.map { $0.memberDomain(meetingConfirmed: isMeetingConfirmed()) },
             memberId: memberId(username: username, members: members),
             status: meetingStatus(),
-            isEmergencyAuthority: isEmergencyAuthority(username: username, members: self.members),
-            emergencyButtonActive: self.certificationTime != nil,
-            emergencyButtonActiveTime: self.certificationTime,
-            emergencyButtonExpiredTime: emergencyButtonExpiredTime(meetingTime: self.meetingTime),
-            isCertified: isCertified(username: username, members: self.members),
-            feeds: self.members.compactMap { $0.feedDomain() }
+            isEmergencyAuthority: isEmergencyAuthority(username: username, members: members),
+            emergencyButtonActive: certificationTime != nil,
+            emergencyButtonActiveTime: certificationTime,
+            emergencyButtonExpiredTime: emergencyButtonExpiredTime(meetingTime: meetingTime),
+            isCertified: isCertified(username: username, members: members),
+            feeds: members.compactMap { $0.feedDomain() }
         )
     }
 

--- a/Baggle/Baggle/Features/Tab/Home/Common/CircleProfileView.swift
+++ b/Baggle/Baggle/Features/Tab/Home/Common/CircleProfileView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import Kingfisher
 
 enum ProfileSize {
+    case extraLarge
     case large // 홈, 본인 프로필 이미지
     case medium // 모임 상세, 멤버 프로필 이미지 -> 추가 수정 필요
     case small // 모임 상세, 피드 게시물 위 프로필 이미지
@@ -17,6 +18,7 @@ enum ProfileSize {
 
     var length: CGFloat {
         switch self {
+        case .extraLarge: return 100
         case .large: return 72
         case .medium: return 64
         case .extraSmall: return 24
@@ -26,7 +28,7 @@ enum ProfileSize {
 
     var borderColor: Color {
         switch self {
-        case .large: return .gray4
+        case .extraLarge, .large: return .gray4
         case .medium: return .primaryNormal
         case .extraSmall: return .gray5
         case .small: return .clear

--- a/Baggle/Baggle/Features/Tab/Home/HomeView.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeView.swift
@@ -134,17 +134,8 @@ extension HomeView {
             }
 
             Spacer()
-
-            KFImage(URL(string: user.profileImageURL ?? ""))
-                .placeholder({ _ in
-                    Image.Profile.profilDefault
-                        .resizable()
-                })
-                .resizable()
-                .aspectRatio(1.0, contentMode: .fill)
-                .cornerRadius(36)
-                .clipped()
-                .frame(width: 72, height: 72)
+            
+            CircleProfileView(imageUrl: user.profileImageURL, size: .large)
         }
         .frame(height: 72)
         .padding(.horizontal, 20)

--- a/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
+++ b/Baggle/Baggle/Features/Tab/MyPage/MyPageView.swift
@@ -33,16 +33,10 @@ struct MyPageView: View {
                             Spacer()
                             
                             VStack(spacing: 16) {
-                                KFImage(URL(string: viewStore.user.profileImageURL ?? ""))
-                                    .placeholder({ _ in
-                                        Image.Profile.profilDefault
-                                            .resizable()
-                                    })
-                                    .resizable()
-                                    .aspectRatio(1.0, contentMode: .fill)
-                                    .frame(width: 100, height: 100)
-                                    .cornerRadius(50)
-                                    .clipped()
+                                CircleProfileView(
+                                    imageUrl: viewStore.user.profileImageURL,
+                                    size: .extraLarge
+                                )
                                 
                                 HStack(alignment: .top, spacing: 6) {
                                     Text(viewStore.user.name)


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 

close #199 
close #203 

## 내용
<!--
로직 설명  
--> 
- CircleProfileView extraLarge 추가
- HomeView, MyPageView 프로필 이미지 CircleProfileView로 변경
- 메모 기본 문구 안뜨는 문제 해결


### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

| 홈 (large) | 마이페이지 (extraLarge) | 메모 기본 문구 추가 |
|--|--|--|
| ![image](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/ee4adc74-06fd-451c-8921-3c10f85809f4) | ![image](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/4e6d6d4d-68c0-41af-b574-1f6f773566e0) | ![IMG_C244705A0511-1](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/8f0e79ed-7d12-4931-b950-05f82ee61fee) |


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

수정사항이 자잘한거라 한 번에 했습니다 ...

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
