### PR TITLE
긴급 버튼 로직 수정

### DIFF
--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		14C44B322A948765009E5379 /* MeetingHomeStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C44B312A948765009E5379 /* MeetingHomeStatus.swift */; };
 		14C44B342A948782009E5379 /* MeetingStampStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C44B332A948782009E5379 /* MeetingStampStatus.swift */; };
 		14C44B362A9487C1009E5379 /* MeetingEmergencyStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C44B352A9487C1009E5379 /* MeetingEmergencyStatus.swift */; };
+		14C44B382A94A9B8009E5379 /* CameraViewStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C44B372A94A9B8009E5379 /* CameraViewStatus.swift */; };
 		14C8DAC72A8F542800371374 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 14C8DAC62A8F542800371374 /* Lottie */; };
 		14C8DACE2A8F645D00371374 /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C8DACD2A8F645D00371374 /* LottieView.swift */; };
 		14C8DAD92A8F656400371374 /* LottieType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C8DAD82A8F656400371374 /* LottieType.swift */; };
@@ -332,6 +333,7 @@
 		14C44B312A948765009E5379 /* MeetingHomeStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingHomeStatus.swift; sourceTree = "<group>"; };
 		14C44B332A948782009E5379 /* MeetingStampStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingStampStatus.swift; sourceTree = "<group>"; };
 		14C44B352A9487C1009E5379 /* MeetingEmergencyStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingEmergencyStatus.swift; sourceTree = "<group>"; };
+		14C44B372A94A9B8009E5379 /* CameraViewStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewStatus.swift; sourceTree = "<group>"; };
 		14C8DACD2A8F645D00371374 /* LottieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieView.swift; sourceTree = "<group>"; };
 		14C8DAD82A8F656400371374 /* LottieType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieType.swift; sourceTree = "<group>"; };
 		14C8F9CB2A8B2905001690C5 /* FeedPhotoRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedPhotoRequestModel.swift; sourceTree = "<group>"; };
@@ -939,6 +941,7 @@
 			children = (
 				14783EE12A7E330700EF58D5 /* CameraFeature.swift */,
 				14783EE32A7E330D00EF58D5 /* CameraView.swift */,
+				14C44B372A94A9B8009E5379 /* CameraViewStatus.swift */,
 			);
 			path = Camera;
 			sourceTree = "<group>";
@@ -1907,6 +1910,7 @@
 				14E4C4B72A6E43CA008643D9 /* CreateTitleFeature.swift in Sources */,
 				2B86CBC02A70F00900800B02 /* HomeFeature.swift in Sources */,
 				2BB7FBC52A89289E0003B75C /* URL.swift in Sources */,
+				14C44B382A94A9B8009E5379 /* CameraViewStatus.swift in Sources */,
 				2B604DDA2A7F60E7000E2DE2 /* CircleProfileView.swift in Sources */,
 				1493A9122A7DE4AB00A2D7CC /* SmallTimerView.swift in Sources */,
 				14EA20B12A8DAB22005C1289 /* AlertCreateMeetingType.swift in Sources */,

--- a/Baggle/Baggle/Core/Models/Alert/MeetingDetail/AlertMeetingDetailType.swift
+++ b/Baggle/Baggle/Core/Models/Alert/MeetingDetail/AlertMeetingDetailType.swift
@@ -13,6 +13,7 @@ enum AlertMeetingDetailType: Equatable {
     case networkError(String) // 네트워크 에러
     case userError // 유저 에러
     case invitation
+    case invalidAuthentication // 유효하지 않는 긴급 버튼 인증 시간
 
     case delete
 }
@@ -21,7 +22,7 @@ extension AlertMeetingDetailType: AlertType {
 
     var buttonType: AlertButtonType {
         switch self {
-        case .meetingNotFound, .meetingIDError, .networkError, .userError, .invitation:
+        case .meetingNotFound, .meetingIDError, .networkError, .userError, .invitation, .invalidAuthentication:
             return .one
         case .delete:
             return .two
@@ -35,6 +36,7 @@ extension AlertMeetingDetailType: AlertType {
         case .networkError: return "네트워크 에러"
         case .userError: return "유저 정보 에러"
         case .invitation: return "초대"
+        case .invalidAuthentication: return "인증 가능한 시간이 아니에요."
         case .delete: return "정말 방을 폭파하시겠어요?"
         }
     }
@@ -44,8 +46,9 @@ extension AlertMeetingDetailType: AlertType {
         case .meetingNotFound: return "서버에서 모임을 찾을 수 없어요."
         case .meetingIDError: return "홈에서 모임 정보를 전달하는데 실패했어요."
         case .networkError(let error): return "네트워크 에러가 발생했어요. 잠시 후 다시 시도해주세요. \(error)"
-        case .userError: return "유저 정보를 불러오는데 에러가 발생했어요. 재로그인 해주세요."
+        case .userError: return "유저 정보를 불러오는데 에러가 발생했어요. 재로그인해주세요."
         case .invitation: return "초대를 할 수가 없어요."
+        case .invalidAuthentication: return "인증 가능한 시간에 다시 시도해주세요."
         case .delete: return "입력하신 약속정보는 모두 삭제돼요!"
         }
     }
@@ -57,6 +60,7 @@ extension AlertMeetingDetailType: AlertType {
         case .networkError: return "확인"
         case .userError: return "재로그인"
         case .invitation: return "확인"
+        case .invalidAuthentication: return "확인"
         case .delete: return "폭파하기"
         }
     }

--- a/Baggle/Baggle/Core/Services/Feed/FeedPhotoService.swift
+++ b/Baggle/Baggle/Core/Services/Feed/FeedPhotoService.swift
@@ -24,7 +24,7 @@ extension FeedPhotoService: DependencyKey {
             guard let token = UserManager.shared.accessToken else {
                 return .userError
             }
-            
+
             let feedPhotoEntity: FeedPhotoEntity = try await networkService
                 .request(.uploadPhoto(requestModel: requestModel, token: token))
             

--- a/Baggle/Baggle/Core/Services/Meeting/MeetingDetail/MeetingDetailService.swift
+++ b/Baggle/Baggle/Core/Services/Meeting/MeetingDetail/MeetingDetailService.swift
@@ -32,7 +32,7 @@ extension MeetingDetailService: DependencyKey {
             }
             
             let meetingDetail = meetingDetailEntity.toDomain(username: username)
-            
+            print(meetingDetail)
             return .success(meetingDetail)
         } catch {
             if let apiError = error as? APIError, apiError == .notFound {

--- a/Baggle/Baggle/Features/Camera/CameraFeature.swift
+++ b/Baggle/Baggle/Features/Camera/CameraFeature.swift
@@ -26,7 +26,7 @@ struct CameraFeature: ReducerProtocol {
         var flipDegree: Double = 0.0
 
         // Status
-        var isCompleted: Bool = false
+        var cameraViewStatus: CameraViewStatus = .loading
         var isUploading: Bool = false
 
         // System - Alert
@@ -140,7 +140,7 @@ struct CameraFeature: ReducerProtocol {
                 return .none
 
             case let .completeTakePhoto(image):
-                state.isCompleted = true
+                state.cameraViewStatus = .result
                 state.resultImage = image
                 return .none
 
@@ -184,7 +184,7 @@ struct CameraFeature: ReducerProtocol {
                 // MARK: Tap - Photo Tap
 
             case .reTakeButtonTapped:
-                state.isCompleted = false
+                state.cameraViewStatus = .camera
                 return .none
 
             case .uploadButtonTapped:
@@ -280,13 +280,13 @@ struct CameraFeature: ReducerProtocol {
                 state.alertType = nil
                 
                 switch alertType {
-                case .cameraConfigureError, .invalidAuthorizationTime, .alreadyUpload,:
+                case .cameraConfigureError, .invalidAuthorizationTime, .alreadyUpload:
                     return .run { _ in await self.dismiss() }
                 case .userError:
                     return .run { send in await send(.delegate(.moveToLogin)) }
                 case .noResultImage:
                     state.resultImage = nil
-                    state.isCompleted = false
+                    state.cameraViewStatus = .camera
                     return .none
                 case .notFound, .networkError, .compressionError:
                     return .run { _ in await self.dismiss() }

--- a/Baggle/Baggle/Features/Camera/CameraFeature.swift
+++ b/Baggle/Baggle/Features/Camera/CameraFeature.swift
@@ -13,6 +13,9 @@ struct CameraFeature: ReducerProtocol {
 
     struct State: Equatable {
         
+        // User
+        var memberID: Int
+        
         // Image
         var viewFinderImage: Image?
         var resultImage: UIImage?
@@ -194,7 +197,7 @@ struct CameraFeature: ReducerProtocol {
                 }
                 
                 guard let feedPhotoRequestModel = FeedPhotoRequestModel(
-                    memberID: 22,
+                    memberID: state.memberID,
                     time: Date(),
                     feedImage: resultImage
                 ) else {
@@ -277,7 +280,7 @@ struct CameraFeature: ReducerProtocol {
                 state.alertType = nil
                 
                 switch alertType {
-                case .cameraConfigureError, .invalidAuthorizationTime, .alreadyUpload:
+                case .cameraConfigureError, .invalidAuthorizationTime, .alreadyUpload,:
                     return .run { _ in await self.dismiss() }
                 case .userError:
                     return .run { send in await send(.delegate(.moveToLogin)) }
@@ -286,7 +289,7 @@ struct CameraFeature: ReducerProtocol {
                     state.isCompleted = false
                     return .none
                 case .notFound, .networkError, .compressionError:
-                    return .none
+                    return .run { _ in await self.dismiss() }
                 }
                 
             case .presentBaggleAlert(let isPresented):

--- a/Baggle/Baggle/Features/Camera/CameraView.swift
+++ b/Baggle/Baggle/Features/Camera/CameraView.swift
@@ -104,10 +104,13 @@ extension CameraView {
     
     private func viewFinderView(viewStore: CameraFeatureViewStore) -> some View {
         ZStack {
-            if viewStore.isCompleted {
-                resultPhotoView(viewStore: viewStore)
-            } else {
+            switch viewStore.cameraViewStatus {
+            case .loading:
+                ProgressView()
+            case .camera:
                 cameraPreview(viewStore: viewStore)
+            case .result:
+                resultPhotoView(viewStore: viewStore)
             }
         }
         .frame(width: viewFinderWidth, height: viewFinderHeight)
@@ -151,7 +154,7 @@ extension CameraView {
     
     private func buttonsView(viewStore: CameraFeatureViewStore) -> some View {
         VStack {
-            if viewStore.isCompleted {
+            if viewStore.cameraViewStatus == .result {
                 photoButtons(viewStore: viewStore)
             } else {
                 cameraButtons(viewStore: viewStore)

--- a/Baggle/Baggle/Features/Camera/CameraViewStatus.swift
+++ b/Baggle/Baggle/Features/Camera/CameraViewStatus.swift
@@ -1,0 +1,14 @@
+//
+//  CameraStatus.swift
+//  Baggle
+//
+//  Created by youtak on 2023/08/22.
+//
+
+import Foundation
+
+enum CameraViewStatus: Equatable {
+    case loading
+    case camera
+    case result
+}

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -23,7 +23,7 @@ struct MeetingDetailFeature: ReducerProtocol {
 
         var meetingId: Int
         var meetingData: MeetingDetail?
-        var memberId: Int = -1
+        var memberID: Int = -1
         var dismiss: Bool = false
         var buttonState: MeetingDetailButtonType = .none
 
@@ -141,7 +141,7 @@ struct MeetingDetailFeature: ReducerProtocol {
                 
             case .updateData(let data):
                 state.meetingData = data
-                state.memberId = data.memberId
+                state.memberID = data.memberId
                 
                 let emergencyStatus = data.emergencyStatus
 
@@ -197,7 +197,7 @@ struct MeetingDetailFeature: ReducerProtocol {
                 }
                         
                 state.emergencyState = EmergencyFeature.State(
-                    memberID: state.meetingId,
+                    memberID: state.memberID,
                     remainTimeUntilExpired: remainTimeUntilExpired
                 )
                 return .none

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -185,7 +185,7 @@ struct MeetingDetailFeature: ReducerProtocol {
                         timer: TimerFeature.State(timerCount: timerCount)
                     )
                 } else {
-                    print("언래핑 에러")
+                    state.alertType = .invalidAuthentication
                 }
                 return .none
 
@@ -272,7 +272,7 @@ struct MeetingDetailFeature: ReducerProtocol {
                 switch alertType {
                 case .meetingNotFound, .meetingIDError:
                     return .run { send in await send(.delegate(.onDisappear))}
-                case .networkError:
+                case .networkError, .invalidAuthentication:
                     return .none
                 case .userError:
                     return .run { send in await send(.delegate(.moveToLogin))}

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -150,9 +150,9 @@ struct MeetingDetailFeature: ReducerProtocol {
                 } else if emergencyStatus == .confirmation {
                     if !data.emergencyButtonActive && data.isEmergencyAuthority {
                         state.buttonState = .emergency
-                    } else if data.emergencyButtonActive && !data.isCertified {
-                        return .run { send in await send(.timerCountChanged) }
                     }
+                } else if emergencyStatus == .onGoing && !data.isCertified {
+                    return .run { send in await send(.timerCountChanged) }
                 }
                 return .none
 
@@ -181,6 +181,7 @@ struct MeetingDetailFeature: ReducerProtocol {
                 if let emergencyButtonActiveTime = state.meetingData?.emergencyButtonActiveTime {
                     let timerCount = emergencyButtonActiveTime.authenticationTimeout()
                     state.usingCamera = CameraFeature.State(
+                        memberID: state.memberID,
                         timer: TimerFeature.State(timerCount: timerCount)
                     )
                 } else {


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #200 

## 내용
<!--
로직 설명  
--> 
- 긴급버튼 호출 시, 기존 meetingID -> memberID로 수정했습니다.
- Meeting Emergency Status에 맞게 로직을 수정했습니다.
- 카메라 인증시 목업 ID를 사용했는데, 실제 ID를 주입했습니다.
- 에러 발생 후 Alert이 나타나면 카운트가 멈추는 에러가 있습니다. 현재는 에러가 발생하면 카메라 화면을 dismiss하도록 수정했습니다.
- 카메라 버튼 예외처리 했습니다. meetingData가 없으면 Alert을 띄웁니다.
- 카메라 preview를 수정했습니다. loading, camera, result 결과를 가지며, 카메라 첫 loading시 로딩 뷰를 보여줍니다.

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/1fbe1aad-1b75-45a5-9a22-1736a3fed613


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- 카메라가 시작시 잠깐 회전돼서 나오네요.

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
