### PR TITLE
카메라 로딩 에러 외 자잘한 수정 

### DIFF
--- a/Baggle/Baggle/Core/Models/Meeting/MeetingDetail/MeetingDetail.swift
+++ b/Baggle/Baggle/Core/Models/Meeting/MeetingDetail/MeetingDetail.swift
@@ -37,14 +37,19 @@ extension MeetingDetail {
     // emergencyStatus -> .terminattion으로 변경
     
     func updateFeed(_ feed: Feed) -> MeetingDetail {
-        MeetingDetail(
+        
+        let updatedMembers = self.members.map {
+            return $0.id == self.memberId ? $0.updateFeed(certImage: feed.feedImageURL) : $0
+        }
+        
+        return MeetingDetail(
             id: self.id,
             name: self.name,
             place: self.place,
             date: self.date,
             time: self.time,
             memo: self.memo,
-            members: self.members,
+            members: updatedMembers,
             memberId: self.memberId,
             stampStatus: self.stampStatus,
             emergencyStatus: .termination,

--- a/Baggle/Baggle/Core/Models/Meeting/MeetingDetail/Memeber.swift
+++ b/Baggle/Baggle/Core/Models/Meeting/MeetingDetail/Memeber.swift
@@ -19,3 +19,17 @@ struct Member: Identifiable, Hashable {
         return lhs.id == rhs.id
     }
 }
+
+extension Member {
+    func updateFeed(certImage: String) -> Member {
+        return Member(
+            id: self.id,
+            name: self.name,
+            profileURL: self.profileURL,
+            isMeetingAuthority: self.isMeetingAuthority,
+            isButtonAuthority: self.isButtonAuthority,
+            certified: true,
+            certImage: certImage
+        )
+    }
+}

--- a/Baggle/Baggle/Core/Models/Network/MeetingDetail/MeetingDetailEntity.swift
+++ b/Baggle/Baggle/Core/Models/Network/MeetingDetail/MeetingDetailEntity.swift
@@ -41,7 +41,7 @@ extension MeetingDetailEntity {
             emergencyButtonActiveTime: self.certificationTime,
             emergencyButtonExpiredTime: emergencyButtonExpiredTime(meetingTime: self.meetingTime),
             isCertified: isCertified(username: username, members: self.members),
-            feeds: self.members.compactMap { $0.feedDomain() }
+            feeds: feeds()
         )
     }
 
@@ -69,5 +69,9 @@ extension MeetingDetailEntity {
 
     private func emergencyButtonExpiredTime(meetingTime: Date) -> Date {
         return self.meetingTime.emergencyTimeOut()
+    }
+
+    private func feeds() -> [Feed] {
+        self.members.compactMap { $0.feedDomain() }.sorted { $0.id > $1.id }
     }
 }

--- a/Baggle/Baggle/Core/Models/Network/MeetingDetail/MeetingDetailEntity.swift
+++ b/Baggle/Baggle/Core/Models/Network/MeetingDetail/MeetingDetailEntity.swift
@@ -32,7 +32,7 @@ extension MeetingDetailEntity {
             date: meetingTime.koreanDate(),
             time: meetingTime.hourMinute(),
             memo: (memo ?? "").isEmpty ? nil : memo,
-            members: members.map { $0.memberDomain(meetingConfirmed: isMeetingConfirmed()) },
+            members: members.map { $0.memberDomain(afterMeetingConfirmed: isMeetingConfirmed()) },
             memberId: memberId(username: username, members: members),
             stampStatus: status.meetingStampStatus(),
             emergencyStatus: status.meetingEmergencyStatus(),
@@ -49,7 +49,7 @@ extension MeetingDetailEntity {
     // 서버에서 멤버가 새로 들어올 때마다 랜덤으로 권한자가 설정됨
     // 모임 확정 시간 전까지 버튼 권한자를 보여주면 안 됨
     private func isMeetingConfirmed() -> Bool {
-        return status == .confirmation
+        return status != .scheduled
     }
     
     private func memberId(username: String, members: [MeetingDetailMemberEntity]) -> Int {

--- a/Baggle/Baggle/Core/Models/Network/MeetingDetail/MeetingDetailMemberEntity.swift
+++ b/Baggle/Baggle/Core/Models/Network/MeetingDetail/MeetingDetailMemberEntity.swift
@@ -28,13 +28,13 @@ struct MeetingDetailMemberEntity: Codable {
 extension MeetingDetailMemberEntity {
 
     // 모임 확정 전까지 버튼 권한자를 안 보여줌
-    func memberDomain(meetingConfirmed: Bool) -> Member {
+    func memberDomain(afterMeetingConfirmed: Bool) -> Member {
         return Member(
             id: self.memberID,
             name: self.nickname,
             profileURL: self.profileImageURL,
             isMeetingAuthority: self.meetingAuthority,
-            isButtonAuthority: meetingConfirmed ? self.buttonAuthority : false,
+            isButtonAuthority: afterMeetingConfirmed ? self.buttonAuthority : false,
             certified: self.feedID != nil,
             certImage: self.feedImageURL
         )

--- a/Baggle/Baggle/Features/Camera/CameraFeature.swift
+++ b/Baggle/Baggle/Features/Camera/CameraFeature.swift
@@ -41,8 +41,12 @@ struct CameraFeature: ReducerProtocol {
     }
 
     enum Action: Equatable {
+
         case onAppear
 
+        // Status
+        case cameraStartSuccess
+        
         // Image
         case viewFinderUpdate(Image?)
         case flipImageRemove
@@ -114,6 +118,8 @@ struct CameraFeature: ReducerProtocol {
 
                     switch cameraStartStatus {
                     case .success:
+                        await send(.cameraStartSuccess)
+
                         let imageStream = cameraService.previewStream()
                             .map { $0.image }
 
@@ -128,6 +134,11 @@ struct CameraFeature: ReducerProtocol {
                         await send(.alertType(.cameraConfigureError))
                     }
                 }
+                
+                // MARK: - Status
+            case .cameraStartSuccess:
+                state.cameraViewStatus = .camera
+                return .none
 
             // MARK: - Image
 

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -286,10 +286,16 @@ struct MeetingDetailFeature: ReducerProtocol {
                 // Child - Camera
 
             case let .usingCamera(.presented(.delegate(.uploadSuccess(feed)))):
-                if let meetingData = state.meetingData {
-                    state.meetingData = meetingData.updateFeed(feed)
+                guard let meetingData = state.meetingData else {
+                    state.alertType = .meetingNotFound
+                    return .none
                 }
-                return .none
+                
+                // 피드 & 멤버 데이터 업데이트
+                let newMeeting = meetingData.updateFeed(feed)
+                
+                // 긴급 버튼 업데이트
+                return .run { send in await send(.updateData(newMeeting))}
                 
             case .usingCamera(.presented(.delegate(.moveToLogin))):
                 return .run { send in await send(.delegate(.moveToLogin))}

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -153,6 +153,8 @@ struct MeetingDetailFeature: ReducerProtocol {
                     }
                 } else if emergencyStatus == .onGoing && !data.isCertified {
                     return .run { send in await send(.timerCountChanged) }
+                } else {
+                    state.buttonState = .none
                 }
                 return .none
 

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
@@ -36,7 +36,6 @@ struct MeetingDetailView: View {
                             
                             // 참여자 목록
                             memberListView(viewStore: viewStore)
-                                .padding(.horizontal, 20)
                                 .drawUnderline(
                                     spacing: 0,
                                     height: 0.5,
@@ -316,9 +315,11 @@ extension MeetingDetailView {
                     .padding(.all, 2)
                 }
             }
+            .padding(.horizontal, 20)
         }
         .padding(.top, 20)
         .padding(.bottom, 16)
+        .scrollIndicators(.hidden)
     }
     
     func feedView(feeds: [Feed], viewStroe: MeetingDetailViewStore) -> some View {


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #207 

## 내용
<!--
로직 설명  
--> 
- 카메라 무한 로딩 에러 해결했습니다. 그런데 progressView가 안 뜨네요. 잘 되던거 또 안 될까바 image가 nil일 때 띄워주도록 따로 수정해보겠습니다.
- 모임 상세 뷰에서 멤버 짤리는 거 해결했습니다. 스크롤 인디케이터도 없앴습니다.
- 피드 ID를 큰 순(최신 순)으로 정렬해줘, 피드 최신순 정렬했습니다.
- 긴급 버튼 할당자 없애지는 거 수정했습니다. 긴급버튼 상태가 .scheduled가 아니면 다 보여주도록 했습니다.
- 카메라 촬영 후 피드 업데이트를 해줬습니다. 멤버, 피드, 긴급 버튼을 업데이트 합니다. 긴급 버튼이 안 사라지는 건 코드 수정 전에 촬영해서 그렇습니다.

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

- 영상이 41MB 라 PR에 안 올려져서 슬랙에 올리겠씁니다....

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
