### PR TITLE
Fix - 긴급버튼 실행 후 바로 카메라 인증으로

### DIFF
--- a/Baggle/Baggle/Core/Models/Meeting/MeetingDetail/MeetingDetail.swift
+++ b/Baggle/Baggle/Core/Models/Meeting/MeetingDetail/MeetingDetail.swift
@@ -22,7 +22,7 @@ struct MeetingDetail: Equatable {
     let isEmergencyAuthority: Bool // 내가 긴급 버튼 권한자
     let emergencyButtonActive: Bool // 긴급 버튼 활성화 여부
     let emergencyButtonActiveTime: Date? // 긴급 버튼 활성화 시간
-    let emergencyButtonExpiredTime: Date // 긴급 버튼 만료 시간 - 모임 10분 전
+    let emergencyButtonExpiredTime: Date // 긴급 버튼 만료 시간 - 모임 15분 전
     let isCertified: Bool
     let feeds: [Feed]
 
@@ -32,6 +32,30 @@ struct MeetingDetail: Equatable {
 }
 
 extension MeetingDetail {
+    
+    // 긴급 버튼 활성화
+    // emergencyStatus -> .ongoing으로 변경
+    
+    func updateEmergemcy(_ emergencyActiveTime: Date) -> MeetingDetail {
+        MeetingDetail(
+            id: id,
+            name: name,
+            place: place,
+            date: date,
+            time: date,
+            memo: memo,
+            members: members,
+            memberId: memberId,
+            stampStatus: stampStatus,
+            emergencyStatus: .onGoing,
+            isEmergencyAuthority: isEmergencyAuthority,
+            emergencyButtonActive: true,
+            emergencyButtonActiveTime: emergencyActiveTime,
+            emergencyButtonExpiredTime: emergencyButtonExpiredTime,
+            isCertified: isCertified,
+            feeds: feeds)
+    }
+    
 
     // 긴급 종료 이후 피드 업데이트
     // emergencyStatus -> .terminattion으로 변경

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -178,7 +178,6 @@ struct MeetingDetailFeature: ReducerProtocol {
                 return .none
 
             case .cameraButtonTapped:
-                print("---- cameraButtonTapped")
                 if let emergencyButtonActiveTime = state.meetingData?.emergencyButtonActiveTime {
                     let timerCount = emergencyButtonActiveTime.authenticationTimeout()
                     state.usingCamera = CameraFeature.State(

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import ComposableArchitecture
 import KakaoSDKShare
 
+// swiftlint:disable:next type_body_length
 struct MeetingDetailFeature: ReducerProtocol {
 
     @Environment(\.openURL) private var openURL
@@ -310,11 +311,12 @@ struct MeetingDetailFeature: ReducerProtocol {
             case .emergencyAction(.presented(.delegate(.moveToLogin))):
                 return .run { send in await send(.delegate(.moveToLogin)) }
                 
-            case .emergencyAction(.presented(.emergencyButtonTapped)):
-                return .run { send in
-                    try await Task.sleep(seconds: 0.4)
-                    await send(.onAppear)
+            case .emergencyAction(.presented(.delegate(.updateEmergencyState(let date)))):
+                if let meetingData = state.meetingData {
+                    let newData = meetingData.updateEmergemcy(date)
+                    return .run { send in await send(.updateData(newData)) }
                 }
+                return .none
             
             case .emergencyAction:
                 return .none

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -178,6 +178,7 @@ struct MeetingDetailFeature: ReducerProtocol {
                 return .none
 
             case .cameraButtonTapped:
+                print("---- cameraButtonTapped")
                 if let emergencyButtonActiveTime = state.meetingData?.emergencyButtonActiveTime {
                     let timerCount = emergencyButtonActiveTime.authenticationTimeout()
                     state.usingCamera = CameraFeature.State(
@@ -301,18 +302,20 @@ struct MeetingDetailFeature: ReducerProtocol {
                 
             case .emergencyAction(.presented(.delegate(.usingCamera))):
                 state.emergencyState = nil
-                return .run { send in
-                    await send(.onAppear)
-                    try await Task.sleep(seconds: 0.4)
-                    await send(.cameraButtonTapped)
-                }
+                return .run { send in await send(.cameraButtonTapped) }
 
             case .emergencyAction(.presented(.delegate(.moveToBack))):
                 state.emergencyState = nil
-                return .run { send in await send(.onAppear) }
+                return .none
                 
             case .emergencyAction(.presented(.delegate(.moveToLogin))):
-                return .run { send in await send(.delegate(.moveToLogin))}
+                return .run { send in await send(.delegate(.moveToLogin)) }
+                
+            case .emergencyAction(.presented(.emergencyButtonTapped)):
+                return .run { send in
+                    try await Task.sleep(seconds: 0.4)
+                    await send(.onAppear)
+                }
             
             case .emergencyAction:
                 return .none

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -301,15 +301,19 @@ struct MeetingDetailFeature: ReducerProtocol {
                 
             case .emergencyAction(.presented(.delegate(.usingCamera))):
                 state.emergencyState = nil
-                return .run { send in await send(.cameraButtonTapped)}
+                return .run { send in
+                    await send(.onAppear)
+                    try await Task.sleep(seconds: 0.4)
+                    await send(.cameraButtonTapped)
+                }
 
             case .emergencyAction(.presented(.delegate(.moveToBack))):
                 state.emergencyState = nil
-                return .none
+                return .run { send in await send(.onAppear) }
                 
             case .emergencyAction(.presented(.delegate(.moveToLogin))):
                 return .run { send in await send(.delegate(.moveToLogin))}
-                
+            
             case .emergencyAction:
                 return .none
 

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
@@ -274,9 +274,7 @@ extension MeetingDetailView {
                 .offset(y: yOffset)
             }
         }
-        .frame(
-            height: (data.memo?.width(15) ?? 0) >= screenSize.width - 40 ? 240 : 188
-        )
+        .frame(height: headerHeight(name: data.name, memo: data.memo))
         .padding(.top, 56)
     }
     
@@ -384,6 +382,20 @@ extension MeetingDetailView {
                 .foregroundColor(.gray6)
         }
         .frame(width: screenSize.width)
+    }
+}
+
+extension MeetingDetailView {
+    func headerHeight(name: String, memo: String?) -> CGFloat {
+        var height: CGFloat = 188
+        if name.width > 200 {
+            height += 31
+        }
+        if let width = memo?.width(15),
+            width >= screenSize.width - 40 {
+            height += 21
+        }
+        return height
     }
 }
 


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
close #208 

## 내용
<!--
로직 설명  
--> 
1. 긴급버튼 실행시 MeetingDetailFeature에서 액션 인지해서 meetingDetail 업데이트 
  - 긴급 버튼 활성화 시간 업데이트가 필요해서, 긴급 버튼 실행했을때 서버 요청을 보내도록 했습니다.
  - 화면 상에서는 긴급 버튼 뷰가 보이지만 MeetingDetail 정보를 업데이트해두기 때문에, 
  긴급 버튼 뷰에서 인증 버튼을 누르면 받아둔 MeetingDetail의 긴급 버튼 활성화 시간을 갖고 바로 카메라 뷰로 넘어갈 수 있습니다.

2. 모임 상세 타이틀 잘리는 문제 해결
  - headerHeight 구하는 함수 추가
<img width="1177" alt="스크린샷 2023-08-22 오후 11 39 09" src="https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/e842179d-552a-4b46-8e91-704e24579964">

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 
긴급 버튼 실행 후 바로 카메라 인증
![ezgif com-resize (39)](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/f262a88b-5ccf-4c2b-a777-25ed8cfcda17)



| 타이틀 1 메모 1 | 타이틀 1 메모 2 | 타이틀 2 메모 1 | 타이틀 2 메모 2 |
|--|--|--|--|
| ![타이틀, 메모 둘다 한줄](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/2f0424de-6707-4348-a809-fd64a17ce23c) |![타이틀 한줄 메모 두줄](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/c57c3e16-428d-408b-b09f-3322c2f207ae) |![타이틀 두줄 메모 한줄](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/54efdf26-d98b-4f82-8bd4-49333cf78be4) |![타이틀, 메모 둘다 두줄](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/630d07b4-428b-4eab-aaf6-a4958a1e5311) |



## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
