### PR TITLE
Fix - 모임 생성 후 홈 업데이트

### DIFF
--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleFeature.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleFeature.swift
@@ -48,10 +48,13 @@ struct CreateTitleFeature: ReducerProtocol {
         case textFieldAction(BaggleTextFeature.Action)
         case path(StackAction<Child.State, Child.Action>)
         
+        case createSuccess
+        
         case delegate(Delegate)
         
         enum Delegate: Equatable {
             case moveToLogin
+//            case createSuccess
         }
     }
 
@@ -133,6 +136,7 @@ struct CreateTitleFeature: ReducerProtocol {
                 }
 
             case .moveToNextScreen:
+                print("🚨 moveToNextScreen")
                 state.path.append(.meetingPlace(CreatePlaceFeature.State()))
                 return .none
 
@@ -193,6 +197,13 @@ struct CreateTitleFeature: ReducerProtocol {
                 state.path.append(.createSuccess(
                     CreateSuccessFeature.State(meetingSuccessModel: meetingSuccessModel))
                 )
+                return .run { send in await send(.createSuccess) }
+//                return .run { send in
+//                    await send(.delegate(.createSuccess))
+//                }
+//                return .none
+                
+            case .createSuccess:
                 return .none
                 
             case let .path(.element(id: id, action: .meetingMemo(.delegate(.moveToBack)))):

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleFeature.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleFeature.swift
@@ -48,13 +48,11 @@ struct CreateTitleFeature: ReducerProtocol {
         case textFieldAction(BaggleTextFeature.Action)
         case path(StackAction<Child.State, Child.Action>)
         
-        case createSuccess
-        
         case delegate(Delegate)
         
         enum Delegate: Equatable {
+            case createSuccess
             case moveToLogin
-//            case createSuccess
         }
     }
 
@@ -136,7 +134,6 @@ struct CreateTitleFeature: ReducerProtocol {
                 }
 
             case .moveToNextScreen:
-                print("🚨 moveToNextScreen")
                 state.path.append(.meetingPlace(CreatePlaceFeature.State()))
                 return .none
 
@@ -197,14 +194,9 @@ struct CreateTitleFeature: ReducerProtocol {
                 state.path.append(.createSuccess(
                     CreateSuccessFeature.State(meetingSuccessModel: meetingSuccessModel))
                 )
-                return .run { send in await send(.createSuccess) }
-//                return .run { send in
-//                    await send(.delegate(.createSuccess))
-//                }
-//                return .none
-                
-            case .createSuccess:
-                return .none
+                return .run { send in
+                    await send(.delegate(.createSuccess))
+                }
                 
             case let .path(.element(id: id, action: .meetingMemo(.delegate(.moveToBack)))):
                 state.path.pop(from: id)

--- a/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
@@ -137,6 +137,7 @@ struct HomeFeature: ReducerProtocol {
 
                 // 초기화
             case .refreshMeetingList:
+                print("🚨 다시 불러옴")
                 state.isRefreshing = true
                 state.homeStatus = .loading
                 state.meetingStatus = .scheduled
@@ -231,6 +232,7 @@ struct HomeFeature: ReducerProtocol {
                 }
 
             case .meetingDetailAction(.delegate(.moveToLogin)):
+                print("🚨 homeFeature - moveToLogin")
                 return .run { send in await send(.delegate(.moveToLogin)) }
                 
             case .meetingDetailAction:

--- a/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
@@ -137,7 +137,6 @@ struct HomeFeature: ReducerProtocol {
 
                 // 초기화
             case .refreshMeetingList:
-                print("🚨 다시 불러옴")
                 state.isRefreshing = true
                 state.homeStatus = .loading
                 state.meetingStatus = .scheduled
@@ -232,7 +231,6 @@ struct HomeFeature: ReducerProtocol {
                 }
 
             case .meetingDetailAction(.delegate(.moveToLogin)):
-                print("🚨 homeFeature - moveToLogin")
                 return .run { send in await send(.delegate(.moveToLogin)) }
                 
             case .meetingDetailAction:

--- a/Baggle/Baggle/Features/Tab/MainTab/MainTabFeature.swift
+++ b/Baggle/Baggle/Features/Tab/MainTab/MainTabFeature.swift
@@ -93,7 +93,13 @@ struct MainTabFeature: ReducerProtocol {
                     await send(.selectTab(previousTab))
                 }
                 
-            case .createMeeting(PresentationAction.presented(.delegate(.moveToLogin))):
+            case .createMeeting(.presented(.createSuccess)):
+                print("🚨 모임 생성 성공")
+                return .run { send in
+                    await send(.homeAction(.refreshMeetingList))
+                }
+                
+            case .createMeeting(.presented(.delegate(.moveToLogin))):
                 return .run { send in await send(.delegate(.moveToLogin))}
 
             case .createMeeting:

--- a/Baggle/Baggle/Features/Tab/MainTab/MainTabFeature.swift
+++ b/Baggle/Baggle/Features/Tab/MainTab/MainTabFeature.swift
@@ -93,8 +93,7 @@ struct MainTabFeature: ReducerProtocol {
                     await send(.selectTab(previousTab))
                 }
                 
-            case .createMeeting(.presented(.createSuccess)):
-                print("🚨 모임 생성 성공")
+            case .createMeeting(.presented(.delegate(.createSuccess))):
                 return .run { send in
                     await send(.homeAction(.refreshMeetingList))
                 }


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
close #214 

## 내용
<!--
로직 설명  
--> 
1. CreateTitleFeature에서 CreateMemoFeature의 .moveToNext(meetingSuccessModel)를 받았을때 .delegate(.createSuccess) 이벤트를 발생시킵니다
2. MainTabFeature에서 CreateTitleFeature의 .delegate(.createSuccess)를 받으면 homeFeature에서 refresh 하게 합니다

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/93c46068-c8a2-435f-acca-8b74561be30d



## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
