### PR TITLE
Fix - 모임 상세 뷰 타이틀 옆 스탬프 위치 수정

### DIFF
--- a/Baggle/Baggle/Core/Common/Extensions/String+.swift
+++ b/Baggle/Baggle/Core/Common/Extensions/String+.swift
@@ -41,4 +41,37 @@ extension String {
         let widthOfString = stringSize.width
         return widthOfString
     }
+    
+    // MARK: - 최대 글자수 기준 줄바꿈한 문자열 생성
+    /// maxCount(기본 11)이상의 글자수이면 줄바꿈해주는 함수
+    func lineChanged(_ maxCount: Int = 11) -> String {
+        if self.count <= maxCount {
+            return self
+        } else {
+            // 최대 글자수보다 크면 줄바꿈한 문자열 리턴
+            var newStr = ""
+            var length = 0
+            let truncatedStr = self.split(separator: " ")
+            
+            for str in truncatedStr.enumerated() {
+                length += str.element.count
+                // 한 줄에 들어갈 글자수가 maxCount보다 크면 줄바꿈, 아니면 그대로 newStr 추가
+                if length >= maxCount {
+                    if str.offset == 0 {
+                        var copyStr = str.element
+                        newStr += copyStr.prefix(maxCount) + "\n"
+                        copyStr.removeFirst(maxCount)
+                        newStr += copyStr
+                        length = copyStr.count
+                        continue
+                    } else {
+                        newStr += "\n"
+                        length = 0
+                    }
+                }
+                newStr += str.element + " "
+            }
+            return newStr
+        }
+    }
 }

--- a/Baggle/Baggle/Core/Models/Network/MeetingDetail/MeetingDetailEntity.swift
+++ b/Baggle/Baggle/Core/Models/Network/MeetingDetail/MeetingDetailEntity.swift
@@ -27,7 +27,7 @@ extension MeetingDetailEntity {
     func toDomain(username: String) -> MeetingDetail {
         MeetingDetail(
             id: meetingID,
-            name: title,
+            name: title.lineChanged(),
             place: place,
             date: meetingTime.koreanDate(),
             time: meetingTime.hourMinute(),

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
@@ -180,9 +180,8 @@ extension MeetingDetailView {
         HStack(alignment: .top) {
             Text("📌")
             
-            Text("\(name)")
+            Text("\(name.lineChanged())")
                 .fontWithLineSpacing(fontType: .subTitle1)
-                .frame(maxWidth: name.width > 200 ? 200 : .none, alignment: .leading)
                 .padding(.trailing, 4)
                 .foregroundColor(.gray9)
             

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
@@ -187,6 +187,7 @@ extension MeetingDetailView {
     func meetingTitleView(name: String, status: MeetingStampStatus) -> some View {
         HStack(alignment: .top) {
             Text("📌")
+                .fontWithLineSpacing(fontType: .subTitle1)
             
             Text("\(name)")
                 .fontWithLineSpacing(fontType: .subTitle1)

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
@@ -188,7 +188,7 @@ extension MeetingDetailView {
         HStack(alignment: .top) {
             Text("📌")
             
-            Text("\(name.lineChanged())")
+            Text("\(name)")
                 .fontWithLineSpacing(fontType: .subTitle1)
                 .padding(.trailing, 4)
                 .foregroundColor(.gray9)
@@ -203,7 +203,7 @@ extension MeetingDetailView {
                 }
             }
             .frame(width: 56, height: 23)
-            .padding(.top, name.width > 200 ? 2.5 : 0) // 두 줄인 경우 상단 패딩 추가
+            .padding(.top, 0)
             
             Spacer()
         }
@@ -413,7 +413,7 @@ extension MeetingDetailView {
 extension MeetingDetailView {
     func headerHeight(name: String, memo: String?) -> CGFloat {
         var height: CGFloat = 188
-        if name.width > 200 {
+        if name.contains("\n") {
             height += 31
         }
         if let width = memo?.width(15),

--- a/Baggle/Baggle/Features/Tab/MainTab/MainTabFeature.swift
+++ b/Baggle/Baggle/Features/Tab/MainTab/MainTabFeature.swift
@@ -85,7 +85,6 @@ struct MainTabFeature: ReducerProtocol {
             case .homeAction:
                 return .none
                 
-                
                 // 모임 생성
             case .createMeeting(PresentationAction.dismiss):
                 let previousTab = state.previousTab


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
close #220 

## 내용
<!--
로직 설명  
--> 
- 텍스트 자체를 11자 기준으로 줄바꿈해주는 함수 생성
  - 기존 방식대로 하면 아래처럼 되는 문제가 있었습니다
![스크린샷 2023-08-24 오후 6 41 43](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/e5ec23e6-a877-4d8f-93a8-44de71790f56)

  - 알아서 text의 width에 따라 길이조절 되는건 안될 것 같아서, 단어별로 나누어 줄바꿈과 함께 조합한 글자를 생성해주는 함수 생성했습니다.
  
<img src="https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/dfaf1bc3-a50e-47af-871d-21aa24881755" width=400 >


<img src="https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/faa0b0de-e0ec-461d-b677-2f7480e7bea9" width=400 >

- 스탬프에 적용하던 패딩 삭제
  - 뷰와 비교해봤을때 패딩 0일때 중앙으로 보여서 수정했습니다

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 
다양한 띄어쓰기 조합에서 각 뷰
| ![IMG_4CE7513C40BB-1](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/63d22d18-4850-4070-8723-ffa52c09fcbb)  | ![IMG_6455](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/0330ec78-bf1e-4d69-afb7-1f1b7a960519)  |  ![IMG_6454](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/e08cdc84-f6c6-404c-b201-e95d1d9305d6) |
|--|--|--|
| ![IMG_6453](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/770f7e72-b790-4ebb-90c1-e7d66de95750) | ![IMG_6452](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/ec21d657-706c-4eb9-9800-fe22838a19f5) | ![IMG_6451](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/877ed4a1-cedc-4a48-813b-ebbe0a269b13) |



## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

줄바꿈 넣어주는 함수가 조금 지저분하기도 한데, 조건에 따라 자르고 붙이다보니 저렇게 되었습니다.. 


## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
