### PR TITLE
Alert & Action Sheet 애니메이션 동작 수정

### DIFF
--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -29,6 +29,9 @@
 		141719762A9302C000AF1C51 /* SplashScreen_animation.json in Resources */ = {isa = PBXBuildFile; fileRef = 141719752A9302C000AF1C51 /* SplashScreen_animation.json */; };
 		141D376F2A681552001067E3 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141D376E2A681552001067E3 /* MainTabView.swift */; };
 		141D37712A681569001067E3 /* MainTabFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141D37702A681569001067E3 /* MainTabFeature.swift */; };
+		141E8CF32AA8A8E000054EDA /* BaggleAlertOneButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141E8CF22AA8A8E000054EDA /* BaggleAlertOneButton.swift */; };
+		141E8CF52AA8A95700054EDA /* BaggleAlertTwoButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141E8CF42AA8A95700054EDA /* BaggleAlertTwoButton.swift */; };
+		141E8CF72AA8A9BD00054EDA /* BaggleAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141E8CF62AA8A9BD00054EDA /* BaggleAlert.swift */; };
 		141FD7632A8CF609003DBFD7 /* MeetingSuccessModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141FD7622A8CF609003DBFD7 /* MeetingSuccessModel.swift */; };
 		1421C0512A7A84A200C20497 /* LoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1421C0502A7A84A200C20497 /* LoginService.swift */; };
 		14283FCF2A8DA32B00FE56F1 /* Moya+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14283FCE2A8DA32B00FE56F1 /* Moya+.swift */; };
@@ -188,7 +191,6 @@
 		2B7EC32D2A822E5B00D78141 /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7EC32C2A822E5B00D78141 /* UINavigationController+.swift */; };
 		2B7EC32F2A8251DC00D78141 /* HomeStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7EC32E2A8251DC00D78141 /* HomeStatus.swift */; };
 		2B7EC3322A826F4D00D78141 /* ImageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7EC3312A826F4D00D78141 /* ImageDetailView.swift */; };
-		2B84696A2A6E7AE200D75D32 /* BaggleAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B84695F2A6E7AE200D75D32 /* BaggleAlert.swift */; };
 		2B84696B2A6E7AE200D75D32 /* BaggleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8469612A6E7AE200D75D32 /* BaggleTextField.swift */; };
 		2B84696C2A6E7AE200D75D32 /* BaggleTextFieldType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8469622A6E7AE200D75D32 /* BaggleTextFieldType.swift */; };
 		2B84696D2A6E7AE200D75D32 /* ShadeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8469642A6E7AE200D75D32 /* ShadeView.swift */; };
@@ -269,6 +271,9 @@
 		141719752A9302C000AF1C51 /* SplashScreen_animation.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = SplashScreen_animation.json; sourceTree = "<group>"; };
 		141D376E2A681552001067E3 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		141D37702A681569001067E3 /* MainTabFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabFeature.swift; sourceTree = "<group>"; };
+		141E8CF22AA8A8E000054EDA /* BaggleAlertOneButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggleAlertOneButton.swift; sourceTree = "<group>"; };
+		141E8CF42AA8A95700054EDA /* BaggleAlertTwoButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggleAlertTwoButton.swift; sourceTree = "<group>"; };
+		141E8CF62AA8A9BD00054EDA /* BaggleAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggleAlert.swift; sourceTree = "<group>"; };
 		141FD7622A8CF609003DBFD7 /* MeetingSuccessModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSuccessModel.swift; sourceTree = "<group>"; };
 		1421C0502A7A84A200C20497 /* LoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginService.swift; sourceTree = "<group>"; };
 		14283FCE2A8DA32B00FE56F1 /* Moya+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Moya+.swift"; sourceTree = "<group>"; };
@@ -427,7 +432,6 @@
 		2B7EC32C2A822E5B00D78141 /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
 		2B7EC32E2A8251DC00D78141 /* HomeStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeStatus.swift; sourceTree = "<group>"; };
 		2B7EC3312A826F4D00D78141 /* ImageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDetailView.swift; sourceTree = "<group>"; };
-		2B84695F2A6E7AE200D75D32 /* BaggleAlert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaggleAlert.swift; sourceTree = "<group>"; };
 		2B8469612A6E7AE200D75D32 /* BaggleTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaggleTextField.swift; sourceTree = "<group>"; };
 		2B8469622A6E7AE200D75D32 /* BaggleTextFieldType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaggleTextFieldType.swift; sourceTree = "<group>"; };
 		2B8469642A6E7AE200D75D32 /* ShadeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShadeView.swift; sourceTree = "<group>"; };
@@ -1595,7 +1599,9 @@
 		2B84695E2A6E7AE200D75D32 /* Alert */ = {
 			isa = PBXGroup;
 			children = (
-				2B84695F2A6E7AE200D75D32 /* BaggleAlert.swift */,
+				141E8CF62AA8A9BD00054EDA /* BaggleAlert.swift */,
+				141E8CF22AA8A8E000054EDA /* BaggleAlertOneButton.swift */,
+				141E8CF42AA8A95700054EDA /* BaggleAlertTwoButton.swift */,
 				14EA20B82A8DBFBD005C1289 /* RightAlertButtonType.swift */,
 			);
 			path = Alert;
@@ -1966,6 +1972,7 @@
 				2B2BA5292A7AB67800A90AE7 /* SelectOwnerView.swift in Sources */,
 				2B7EC32D2A822E5B00D78141 /* UINavigationController+.swift in Sources */,
 				149C0F462A77850500B95A36 /* CreateSuccessFeature.swift in Sources */,
+				141E8CF52AA8A95700054EDA /* BaggleAlertTwoButton.swift in Sources */,
 				2BDEAC762A86024E00D698E6 /* KeychainManager.swift in Sources */,
 				1432BE642A68168A0098AAA9 /* TabType.swift in Sources */,
 				143C7BFE2A875508004D83FD /* WithdrawServiceResult.swift in Sources */,
@@ -1988,6 +1995,7 @@
 				14E506542A6B8ED3008D5778 /* SignUpSuccessView.swift in Sources */,
 				14486D2C2A8B0C7400831DDD /* DateFormatter+.swift in Sources */,
 				2B84696B2A6E7AE200D75D32 /* BaggleTextField.swift in Sources */,
+				141E8CF72AA8A9BD00054EDA /* BaggleAlert.swift in Sources */,
 				146237432A877C1600FBE121 /* SettingListHeader.swift in Sources */,
 				149C0F482A77850A00B95A36 /* CreateSuccessView.swift in Sources */,
 				2BA345A52A6EB02F00B7E2BD /* BaggleTag.swift in Sources */,
@@ -2023,6 +2031,7 @@
 				14EF8C242A8CAC5B00B0FA40 /* FeedUser.swift in Sources */,
 				2B7B4D812A853ED300283248 /* FeedAPI.swift in Sources */,
 				14F6D9FC2A80748600C8C19C /* Image+.swift in Sources */,
+				141E8CF32AA8A8E000054EDA /* BaggleAlertOneButton.swift in Sources */,
 				146C51F02A79429E00FF3142 /* SelectDateView.swift in Sources */,
 				14EA20BC2A8DCBCD005C1289 /* AlertCameraType.swift in Sources */,
 				14CF68EE2A847C5C00E457DF /* LoginPlatform.swift in Sources */,
@@ -2043,7 +2052,6 @@
 				2B39F21C2A738BB100E034A3 /* SendInvitation.swift in Sources */,
 				1462373E2A87760E00FBE121 /* SettingListRow.swift in Sources */,
 				147E40EE2AA03BB90044698B /* MeetingDateButton.swift in Sources */,
-				2B84696A2A6E7AE200D75D32 /* BaggleAlert.swift in Sources */,
 				147E40F52AA0454F0044698B /* MeetingEditFeature.swift in Sources */,
 				14E577AC2A80973B00119FB3 /* EmergencyView.swift in Sources */,
 				2BCACB7F2A742C9000892D45 /* BaggleTextFeature.swift in Sources */,

--- a/Baggle/Baggle/DesignSystem/Extension/View+.swift
+++ b/Baggle/Baggle/DesignSystem/Extension/View+.swift
@@ -103,21 +103,21 @@ extension View {
     }
 }
 
-// MARK: - Error Alert
+// MARK: - Alert
 
 extension View {
-    func errorAlert(
+    func baggleAlert (
         isPresented: Binding<Bool>,
-        description: String,
+        alertType: AlertType?,
         action: @escaping () -> Void
     ) -> some View {
-        BaggleAlertOneButton(
-            isPresented: isPresented,
-            title: "에러가 발생했어요",
-            description: description,
-            buttonTitle: "돌아가기") {
-                action()
-            }
+        ZStack {
+            self
+            
+            ShadeView(isPresented: isPresented, enableTouch: false)
+            
+            BaggleAlert(isPresented: isPresented, alertType: alertType, action: action)
+        }
     }
 }
 
@@ -130,14 +130,13 @@ extension View {
     ) -> some View {
         ZStack {
             self
-            if isPresented.wrappedValue {
-                ShadeView(isPresented: isPresented)
-                
-                BaggleActionSheet(isShowing: isPresented, action: content)
-            }
+            
+            ShadeView(isPresented: isPresented)
+            
+            BaggleActionSheet(isShowing: isPresented, action: content)
         }
     }
-    
+
     func addAction(_ action: @escaping () -> Void, role: ButtonRole? = nil) -> Button<Self> {
         Button(role: role) {
             action()

--- a/Baggle/Baggle/DesignSystem/View/ActionSheet/BaggleActionSheet.swift
+++ b/Baggle/Baggle/DesignSystem/View/ActionSheet/BaggleActionSheet.swift
@@ -19,31 +19,32 @@ struct BaggleActionSheet<Content: View>: View {
     }
     
     var body: some View {
-        VStack(spacing: 15) {
-            Spacer()
-            
-            // 액션 버튼
-            VStack(spacing: 0) {
-                action
+        VStack {
+            if isShowing {
+                VStack(spacing: 15) {
+                    Spacer()
+                    
+                    // 액션 버튼
+                    VStack(spacing: 0) {
+                        action
+                    }
+                    .buttonStyle(ActionButtonStyle())
+                    .frame(width: UIScreen.main.bounds.width - 40)
+                    .background(.white)
+                    .cornerRadius(8)
+                    
+                    // 취소 버튼
+                    Button("닫기") {
+                        isShowing = false
+                    }
+                    .buttonStyle(CancelActionButtonStyle())
+                }
+                .transition(.move(edge: .bottom))
+                .onReceive(NotificationCenter.default.publisher(for: .actionSheetDismiss)) { _ in
+                    isShowing = false
+                }
             }
-            .buttonStyle(ActionButtonStyle())
-            .frame(width: UIScreen.main.bounds.width - 40)
-            .background(.white)
-            .cornerRadius(8)
-            
-            // 취소 버튼
-            Button("닫기") {
-                withAnimation { isShowing = false }
-            }
-            .buttonStyle(CancelActionButtonStyle())
         }
-        .opacity(isShowing ? 1 : 0)
-        .transition(.move(edge: .bottom).combined(with: .opacity))
-        .animation(.easeInOut(duration: 0.2), value: isShowing)
-        .onReceive(NotificationCenter.default.publisher(for: .actionSheetDismiss)) { _ in
-            withAnimation {
-                isShowing = false
-            }
-        }
+        .animation(.easeInOut(duration: 0.3), value: isShowing)
     }
 }

--- a/Baggle/Baggle/DesignSystem/View/Alert/BaggleAlert.swift
+++ b/Baggle/Baggle/DesignSystem/View/Alert/BaggleAlert.swift
@@ -1,216 +1,70 @@
 //
 //  BaggleAlert.swift
-//  PromiseDemo
+//  Baggle
 //
-//  Created by 양수빈 on 2023/07/23.
+//  Created by youtak on 2023/09/06.
 //
 
 import SwiftUI
 
-import ComposableArchitecture
-
-/**
- - description:
- 
- Baggle Custom Alert 입니다.
- 
- - parameters:
- - isPresented: 부모 뷰에서 alert를 보이기 위한 Binding<Bool> 변수
- - title : alert 타이틀
- - description: 타이틀 하단의 설명
- - leftButtonTitle: 왼쪽 버튼 타이틀 (default: 아니오
- - rightButtonTitiel: 오른쪽 버튼 타이틀 (default: 네)
- - rightButtonAction: 오른쪽 버튼 탭했을 때 실행할 액션
- 
- - note:
- 
- @State var isAlertPresented: Bool = false
- 
- var body: some View {
- ZStack {
- // 보여질 뷰
- 
- BaggleAlert(isPresented: $isAlertPresented, title: "제목입니다") {
- // 오른쪽 버튼 탭했을 때 수행할 액션
- }
- }
- }
- 
- */
-
-struct BaggleAlertOneButton: View {
-    
-    private var alertWidth: CGFloat {
-        screenSize.width - 40
-    }
+struct BaggleAlert: View {
     
     @Binding var isPresented: Bool
     
-    private var title: String
-    private var description: String?
-    private var buttonTitle: String
-    private var buttonAction: (() -> Void)?
+    private var alertType: AlertType?
+    private var action: () -> Void
     
     init(
         isPresented: Binding<Bool>,
-        title: String,
-        description: String? = nil,
-        buttonTitle: String,
-        buttonAction: (() -> Void)? = nil
+        alertType: AlertType?,
+        action: @escaping () -> Void
     ) {
         self._isPresented = isPresented
-        self.title = title
-        self.description = description
-        self.buttonTitle = buttonTitle
-        self.buttonAction = buttonAction
+        self.alertType = alertType
+        self.action = action
     }
     
     var body: some View {
         ZStack {
-            ShadeView(isPresented: $isPresented, enableTouch: false)
-            
-            VStack(spacing: 40) {
-                
-                VStack(spacing: 2) {
-                    Text(title)
-                        .font(.Baggle.subTitle2)
-                        .foregroundColor(.gray11)
-                        .padding(.vertical, 5)
-                    
-                    if let description {
-                        Text(description)
-                            .font(.Baggle.body2)
-                            .foregroundColor(.gray8)
-                            .padding(.vertical, 4)
+            if isPresented, let alertType = alertType {
+                if alertType.buttonType == .one {
+                    BaggleAlertOneButton(
+                        isPresented: $isPresented,
+                        title: alertType.title,
+                        description: alertType.description,
+                        buttonTitle: alertType.buttonTitle
+                    ) {
+                        action()
+                    }
+                } else if alertType.buttonType == .two {
+                    BaggleAlertTwoButton(
+                        isPresented: $isPresented,
+                        title: alertType.title,
+                        description: alertType.description,
+                        alertType: .destructive,
+                        rightButtonTitle: alertType.buttonTitle,
+                        leftButtonAction: nil
+                    ) {
+                        action()
                     }
                 }
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 20)
-                
-                HStack {
-                    
-                    Button {
-                        buttonAction?()
-                        isPresented.toggle()
-                    } label: {
-                        Text(buttonTitle)
-                            .frame(width: alertWidth/2, height: 52)
-                    }
-                    .buttonStyle(
-                        BagglePrimaryStyle(size: .medium)
-                    )
-                }
-                .frame(width: alertWidth, height: 54)
             }
-            .padding(.top, 52)
-            .padding(.bottom, 20)
-            .frame(width: alertWidth)
-            .background(.white)
-            .cornerRadius(20)
-            .opacity(self.isPresented ? 1 : 0)
-            .transition(.opacity.animation(.easeInOut))
-            .animation(.easeInOut(duration: 0.2), value: self.isPresented)
         }
+        .animation(.easeInOut(duration: 0.3), value: self.isPresented)
     }
 }
 
-struct BaggleAlertTwoButton: View {
-
-    private var alertWidth: CGFloat {
-        screenSize.width - 40
-    }
-    
-    private var buttonWidth: CGFloat {
-        (alertWidth - 48) / 2
-    }
-    
-    @Binding var isPresented: Bool
-    
-    private var title: String
-    private var description: String?
-    private let alertType: RightAlertButtonType
-    
-    private var leftButtonTitle: String
-    private var rightButtonTitle: String
-    private let leftButtonAction: (() -> Void)?
-    private let rightButtonAction: () -> Void
-    
-    init(
-        isPresented: Binding<Bool>,
-        title: String,
-        description: String? = nil,
-        alertType: RightAlertButtonType = .none,
-        leftButtonTitle: String = "취소",
-        rightButtonTitle: String = "네",
-        leftButtonAction: (() -> Void)? = nil,
-        rightButtonAction: @escaping () -> Void
-    ) {
-        self._isPresented = isPresented
-        self.title = title
-        self.description = description
-        self.alertType = alertType
-        self.leftButtonTitle = leftButtonTitle
-        self.rightButtonTitle = rightButtonTitle
-        self.leftButtonAction = leftButtonAction
-        self.rightButtonAction = rightButtonAction
-    }
-    
-    var body: some View {
+struct BaggleAlert_Previews: PreviewProvider {
+    static var previews: some View {
         ZStack {
-            ShadeView(isPresented: $isPresented)
+            Color.gray11.opacity(0.7)
             
-            VStack(spacing: 40) {
-                
-                VStack(spacing: 2) {
-                    Text(title)
-                        .font(.Baggle.subTitle2)
-                        .foregroundColor(.gray11)
-                        .padding(.vertical, 5)
-                    
-                    if let description {
-                        Text(description)
-                            .font(.Baggle.body2)
-                            .foregroundColor(.gray8)
-                            .padding(.vertical, 4)
-                    }
-                }
-                .multilineTextAlignment(.center)
-                
-                HStack {
-                    Button {
-                        leftButtonAction?()
-                        isPresented.toggle()
-                    } label: {
-                        Text(leftButtonTitle)
-                            .font(.Baggle.button1)
-                            .foregroundColor(.gray7)
-                            .frame(width: buttonWidth, height: 52)
-                            .background(Color.gray4)
-                            .cornerRadius(8)
-                    }
-                    
-                    Button {
-                        rightButtonAction()
-                        isPresented.toggle()
-                    } label: {
-                        Text(rightButtonTitle)
-                            .font(.Baggle.button1)
-                            .foregroundColor(.white)
-                            .frame(width: buttonWidth, height: 52)
-                            .background(alertType.backgroundColor)
-                            .cornerRadius(8)
-                    }
-                }
-                .frame(width: alertWidth, height: 54)
+            BaggleAlert(
+                isPresented: .constant(true),
+                alertType: AlertMeetingDetailType.delete
+            ) {
+                print("눌렀어")
             }
-            .padding(.top, 52)
-            .padding(.bottom, 20)
-            .frame(width: alertWidth)
-            .background(.white)
-            .cornerRadius(20)
-            .opacity(self.isPresented ? 1 : 0)
-            .transition(.opacity.animation(.easeInOut))
-            .animation(.easeInOut(duration: 0.2), value: self.isPresented)
         }
     }
 }

--- a/Baggle/Baggle/DesignSystem/View/Alert/BaggleAlertOneButton.swift
+++ b/Baggle/Baggle/DesignSystem/View/Alert/BaggleAlertOneButton.swift
@@ -1,0 +1,93 @@
+//
+//  BaggleAlertOneButton.swift
+//  Baggle
+//
+//  Created by youtak on 2023/09/06.
+//
+
+import SwiftUI
+
+struct BaggleAlertOneButton: View {
+    
+    private var alertWidth: CGFloat {
+        screenSize.width - 40
+    }
+    
+    @Binding var isPresented: Bool
+    
+    private var title: String
+    private var description: String?
+    private var buttonTitle: String
+    private var buttonAction: (() -> Void)?
+    
+    init(
+        isPresented: Binding<Bool>,
+        title: String,
+        description: String? = nil,
+        buttonTitle: String,
+        buttonAction: (() -> Void)? = nil
+    ) {
+        self._isPresented = isPresented
+        self.title = title
+        self.description = description
+        self.buttonTitle = buttonTitle
+        self.buttonAction = buttonAction
+    }
+    
+    var body: some View {
+        ZStack {
+            VStack(spacing: 40) {
+                
+                VStack(spacing: 2) {
+                    Text(title)
+                        .font(.Baggle.subTitle2)
+                        .foregroundColor(.gray11)
+                        .padding(.vertical, 5)
+                    
+                    if let description {
+                        Text(description)
+                            .font(.Baggle.body2)
+                            .foregroundColor(.gray8)
+                            .padding(.vertical, 4)
+                    }
+                }
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 20)
+                
+                HStack {
+                    
+                    Button {
+                        buttonAction?()
+                        isPresented.toggle()
+                    } label: {
+                        Text(buttonTitle)
+                            .frame(width: alertWidth/2, height: 52)
+                    }
+                    .buttonStyle(
+                        BagglePrimaryStyle(size: .medium)
+                    )
+                }
+                .frame(width: alertWidth, height: 54)
+            }
+            .padding(.top, 52)
+            .padding(.bottom, 20)
+            .frame(width: alertWidth)
+            .background(.white)
+            .cornerRadius(20)
+        }
+    }
+}
+
+struct BaggleAlertOneButton_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            Color.gray11.opacity(0.7)
+            
+            BaggleAlertOneButton(
+                isPresented: .constant(true),
+                title: "버튼 하나짜리 Alert입니다.",
+                buttonTitle: "확인"
+            )
+        }
+    }
+}

--- a/Baggle/Baggle/DesignSystem/View/Alert/BaggleAlertTwoButton.swift
+++ b/Baggle/Baggle/DesignSystem/View/Alert/BaggleAlertTwoButton.swift
@@ -1,0 +1,120 @@
+//
+//  BaggleAlertTwoButton.swift
+//  Baggle
+//
+//  Created by youtak on 2023/09/06.
+//
+
+import SwiftUI
+
+struct BaggleAlertTwoButton: View {
+    
+    private var alertWidth: CGFloat {
+        screenSize.width - 40
+    }
+    
+    private var buttonWidth: CGFloat {
+        (alertWidth - 48) / 2
+    }
+    
+    @Binding var isPresented: Bool
+    
+    private var title: String
+    private var description: String?
+    private let alertType: RightAlertButtonType
+    
+    private var leftButtonTitle: String
+    private var rightButtonTitle: String
+    private let leftButtonAction: (() -> Void)?
+    private let rightButtonAction: () -> Void
+    
+    init(
+        isPresented: Binding<Bool>,
+        title: String,
+        description: String? = nil,
+        alertType: RightAlertButtonType = .none,
+        leftButtonTitle: String = "취소",
+        rightButtonTitle: String = "네",
+        leftButtonAction: (() -> Void)? = nil,
+        rightButtonAction: @escaping () -> Void
+    ) {
+        self._isPresented = isPresented
+        self.title = title
+        self.description = description
+        self.alertType = alertType
+        self.leftButtonTitle = leftButtonTitle
+        self.rightButtonTitle = rightButtonTitle
+        self.leftButtonAction = leftButtonAction
+        self.rightButtonAction = rightButtonAction
+    }
+    
+    var body: some View {
+        ZStack {
+            VStack(spacing: 40) {
+                
+                VStack(spacing: 2) {
+                    Text(title)
+                        .font(.Baggle.subTitle2)
+                        .foregroundColor(.gray11)
+                        .padding(.vertical, 5)
+                    
+                    if let description {
+                        Text(description)
+                            .font(.Baggle.body2)
+                            .foregroundColor(.gray8)
+                            .padding(.vertical, 4)
+                    }
+                }
+                .multilineTextAlignment(.center)
+                
+                HStack {
+                    Button {
+                        leftButtonAction?()
+                        isPresented.toggle()
+                    } label: {
+                        Text(leftButtonTitle)
+                            .font(.Baggle.button1)
+                            .foregroundColor(.gray7)
+                            .frame(width: buttonWidth, height: 52)
+                            .background(Color.gray4)
+                            .cornerRadius(8)
+                    }
+                    
+                    Button {
+                        rightButtonAction()
+                        isPresented.toggle()
+                    } label: {
+                        Text(rightButtonTitle)
+                            .font(.Baggle.button1)
+                            .foregroundColor(.white)
+                            .frame(width: buttonWidth, height: 52)
+                            .background(alertType.backgroundColor)
+                            .cornerRadius(8)
+                    }
+                }
+                .frame(width: alertWidth, height: 54)
+            }
+            .padding(.top, 52)
+            .padding(.bottom, 20)
+            .frame(width: alertWidth)
+            .background(.white)
+            .cornerRadius(20)
+        }
+    }
+}
+
+struct BaggleAlertTwoButton_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            Color.gray11.opacity(0.7)
+            
+            BaggleAlertTwoButton(
+                isPresented: .constant(true),
+                title: "2개 버튼 Alert입니다",
+                rightButtonAction: {
+                    print("버튼 액션")
+                }
+            )
+        }
+    }
+}

--- a/Baggle/Baggle/DesignSystem/View/Common/ShadeView.swift
+++ b/Baggle/Baggle/DesignSystem/View/Common/ShadeView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ShadeView: View {
-
+    
     @Binding private var isPresented: Bool
     let enableTouch: Bool
     
@@ -16,17 +16,20 @@ struct ShadeView: View {
         self._isPresented = isPresented
         self.enableTouch = enableTouch
     }
-
+    
     var body: some View {
-        Color.gray10
-            .opacity(isPresented ? 0.7 : 0)
-            .edgesIgnoringSafeArea(.all)
-            .transition(.opacity.animation(.easeInOut))
-            .animation(.easeInOut(duration: 0.2), value: self.isPresented)
-            .onTapGesture {
-                if enableTouch {
-                    withAnimation { isPresented.toggle() }
-                }
+        ZStack {
+            if isPresented {
+                Color.gray10
+                    .opacity(0.7)
+                    .edgesIgnoringSafeArea(.all)
             }
+        }
+        .animation(.easeInOut(duration: 0.2), value: self.isPresented)
+        .onTapGesture {
+            if enableTouch {
+                isPresented.toggle()
+            }
+        }
     }
 }

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -176,7 +176,6 @@ struct MeetingDetailFeature: ReducerProtocol {
                 // MARK: - Tap
 
             case .deleteButtonTapped:
-                state.isAlertPresented = true
                 return .run { send in await send(.alertTypeChanged(.meetingDelete))}
                 
             case .editButtonTapped:

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -19,15 +19,19 @@ struct MeetingDetailFeature: ReducerProtocol {
         // View
         var isLoading: Bool = false
         
+        // Alert
+        var isAlertPresented: Bool = false
+        var alertType: AlertMeetingDetailType?
+        
+        // Action Sheet
+        var isActionSheetPresented: Bool = false
+
         // Meeting
 
         var meetingId: Int
         var meetingData: MeetingDetail?
         var dismiss: Bool = false
         var buttonState: MeetingDetailButtonType = .none
-
-        // Alert
-        var alertType: AlertMeetingDetailType?
         
         // Feed
         var isImageTapped: Bool = false
@@ -72,8 +76,11 @@ struct MeetingDetailFeature: ReducerProtocol {
 
         // Alert
         case presentAlert(Bool)
-        case presentInvitationAlert
+        case alertTypeChanged(AlertMeetingDetailType)
         case alertButtonTapped
+        
+        // ActionSheet
+        case presentActionSheet(Bool)
         
         // Child
         case selectOwner(PresentationAction<SelectOwnerFeature.Action>)
@@ -115,8 +122,7 @@ struct MeetingDetailFeature: ReducerProtocol {
                 let meetingID = state.meetingId
                 
                 if meetingID == Const.ErrorID.meeting {
-                    state.alertType = .meetingIDError
-                    return .none
+                    return .run { send in await send(.alertTypeChanged(.meetingIDError))}
                 }
                 state.isLoading = true
                 
@@ -136,14 +142,11 @@ struct MeetingDetailFeature: ReducerProtocol {
                 case let .success(meetingDetail):
                     return .run { send in await send(.updateData(meetingDetail)) }
                 case .notFound:
-                    state.alertType = .meetingNotFound
-                    return .none
+                    return .run { send in await send(.alertTypeChanged(.meetingNotFound))}
                 case .userError:
-                    state.alertType = .userError
-                    return .none
+                    return .run { send in await send(.alertTypeChanged(.userError))}
                 case .networkError(let description):
-                    state.alertType = .networkError(description)
-                    return .none
+                    return .run { send in await send(.alertTypeChanged(.networkError(description)))}
                 }
                 
             case .updateData(let data):
@@ -173,25 +176,25 @@ struct MeetingDetailFeature: ReducerProtocol {
                 // MARK: - Tap
 
             case .deleteButtonTapped:
-                state.alertType = .meetingDelete
-                return .none
+                state.isAlertPresented = true
+                return .run { send in await send(.alertTypeChanged(.meetingDelete))}
                 
             case .editButtonTapped:
                 guard let meetingEdit = state.meetingData?.toMeetingEdit() else {
-                    state.alertType = .meetingUnwrapping
-                    return .none // 실패시 MeetingDetail에서 Date생성하는 함수를 확인할 것
+                    // 실패시 MeetingDetail에서 Date생성하는 함수를 확인할 것
+                    return .run { send in await send(.alertTypeChanged(.meetingUnwrapping))}
                 }
                 return .run { send in await send(.delegate(.moveToEdit(meetingEdit))) }
 
             case .leaveButtonTapped:
+                
                 guard let meetingData = state.meetingData else {
-                    state.alertType = .meetingUnwrapping
-                    return .none
+                    return .run { send in await send(.alertTypeChanged(.meetingUnwrapping))}
                 }
                 
                 // 방장 혼자만 있는 경우
                 if meetingData.members.count == 1 {
-                    state.alertType = .meetingLeaveFail
+                    return .run { send in await send(.alertTypeChanged(.meetingLeaveFail))}
                 } else {
                     state.selectOwner = SelectOwnerFeature.State()
                 }
@@ -203,8 +206,7 @@ struct MeetingDetailFeature: ReducerProtocol {
 
             case .cameraButtonTapped:
                 guard let meetingData = state.meetingData else {
-                    state.alertType = .meetingUnwrapping
-                    return .none
+                    return .run { send in await send(.alertTypeChanged(.meetingUnwrapping))}
                 }
                 
                 let memberID = meetingData.memberID
@@ -216,14 +218,13 @@ struct MeetingDetailFeature: ReducerProtocol {
                         timer: TimerFeature.State(timerCount: timerCount)
                     )
                 } else {
-                    state.alertType = .invalidAuthentication
+                    return .run { send in await send(.alertTypeChanged(.invalidAuthentication))}
                 }
                 return .none
 
             case .emergencyButtonTapped:
                 guard let meetingData = state.meetingData else {
-                    state.alertType = .meetingUnwrapping
-                    return .none
+                    return .run { send in await send(.alertTypeChanged(.meetingUnwrapping))}
                 }
                 
                 let memberID = meetingData.memberID
@@ -289,10 +290,12 @@ struct MeetingDetailFeature: ReducerProtocol {
                 if !isPresented {
                     state.alertType = nil
                 }
+                state.isAlertPresented = isPresented
                 return .none
-                
-            case .presentInvitationAlert:
-                state.alertType = .invitation
+
+            case .alertTypeChanged(let alertType):
+                state.alertType = alertType
+                state.isAlertPresented = true
                 return .none
 
             case .alertButtonTapped:
@@ -318,12 +321,16 @@ struct MeetingDetailFeature: ReducerProtocol {
                     return .none
                 }
 
+                // Action Sheet
+            case .presentActionSheet(let isPresented):
+                state.isActionSheetPresented = isPresented
+                return .none
+                
                 // Child - Camera
 
             case let .usingCamera(.presented(.delegate(.uploadSuccess(feed)))):
                 guard let meetingData = state.meetingData else {
-                    state.alertType = .meetingNotFound
-                    return .none
+                    return .run { send in await send(.alertTypeChanged(.meetingNotFound))}
                 }
                 
                 // 피드 & 멤버 데이터 업데이트
@@ -376,7 +383,7 @@ struct MeetingDetailFeature: ReducerProtocol {
                 if let emergencyButtonActiveTime = state.meetingData?.emergencyButtonActiveTime {
                     state.timerState.timerCount = emergencyButtonActiveTime.authenticationTimeout()
                 } else {
-                    state.alertType = .meetingUnwrapping
+                    return .run { send in await send(.alertTypeChanged(.meetingUnwrapping))}
                 }
                 
                 // button의 onAppear 때 타이머 시작이 되기 때문에, 타이머 시간을 설정하고 버튼이 나타나야함


### PR DESCRIPTION
- if 위치 변경

## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #241

## 내용
<!--
로직 설명  
--> 
- 모임 삭제 구현하려는데 Alert에 애니메이션이 동작 안 되서 먼저 수정했습니다. 수정하면서 Action Sheet의 이상 애니메이션도 수정하고 viewStore state로 관리하게 수정했습니다.

|수정 전|수정 후|
|:---:|:---:|
|![설명 애니메이션 수정 전](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/c66fe7ab-2500-48db-a20d-424e787e48a0)|![설명 애니메이션 수정 후](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/6fdf3760-2e4f-423a-a868-486d03b7b720)|

`BaggleAlert`, `shadeView`, `BaggleActionSheet` 전부 다 위와 같이 컨테이너 View로 감싸주고 애니메이션을 적용했습니다.

- 수빈님이 작성한 'actionSheet'처럼 `View+`에 `bagglAlert`을 만들었습니다.   
   AlertType 작성할 때만 설정하면 view는 자동으로 설정되도록 `Baggle One Button`과 `Baggle Two Button`을 `BaggleAlert`으로 감싸주었습니다. 
- Baggle Alert과 ShadeView에 Binding<Bool>타입 변수를 넣어줘야 해서 `alertType != nil` 말고 `isAlertPresented` state를 만들었습니다.  막상 사용해보니 더 명시적인 것 같습니다. alert 나타날 때 state 두 개를 설정해줘야 해서 action을 하나 만들어서 관리하고 있습니다. (`Meeting Detail View` - `alertTypeChanged` 참고)


### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

- 오류

|action Sheet 애니메이션 끝날 때 팅김|alert 애니메이션 작동 X|
|:---:|:---:|
|![action sheet 애니메이션 팅김](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/41f8ce75-85f7-4f4a-8803-6f7894f770fc)|![alert 애니메이션 안 됨](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/d771ae47-cc6a-45dd-afb1-44c77df50128)|


- 성공

![애니메이션 정상 작동](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/5f3522c3-8bf6-4d13-8c8a-841fbd8cbf7d)




## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 
- `presentBagglAlert`이라고 하려다 인자 안에 isPresented가 있어 중복되는 느낌이라 안 넣었습니다. 괜찮다면 `presentActionSheet`도 `actionSheet`으로 수정하겠습니다.
- 우선 MeetingDetailView Alert만 수정했는데 추가 수정 사항 없으면 다 수정하겠습니다.
- 수빈님이 AlertType 프로토콜 만들어주셔서 쉽게 작업할 수 있었습니다 🙌
- API 먼저 해야하는데 애니메이션이 눈에 거슬려 도저히 안 할 수가 없었습니다.....

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->

