### PR TITLE
방장이 모임 폭파 & 모임 떠나기 & Action Sheet 분기 처리

### DIFF
--- a/Baggle/Baggle/Core/API/MeetingAPI.swift
+++ b/Baggle/Baggle/Core/API/MeetingAPI.swift
@@ -14,6 +14,7 @@ enum MeetingAPI {
     case meetingList(requestModel: HomeRequestModel, token: String)
     case meetingDetail(meetingID: Int, token: String)
     case createMeeting(requestModel: MeetingCreateRequestModel, token: String)
+    case deleteMeeting(meetingID: Int, token: String)
 }
 
 extension MeetingAPI: BaseAPI {
@@ -27,6 +28,7 @@ extension MeetingAPI: BaseAPI {
         case .meetingList: return ""
         case .meetingDetail: return "detail"
         case .createMeeting: return ""
+        case .deleteMeeting: return ""
         }
     }
     
@@ -40,6 +42,8 @@ extension MeetingAPI: BaseAPI {
             return HeaderType.jsonWithBearer(token: token).value
         case .createMeeting(_, let token):
             return HeaderType.jsonWithBearer(token: token).value
+        case .deleteMeeting(_ , let token):
+            return HeaderType.jsonWithBearer(token: token).value
         }
     }
     
@@ -49,6 +53,7 @@ extension MeetingAPI: BaseAPI {
         switch self {
         case .meetingDetail, .meetingList: return .get
         case .createMeeting: return .post
+        case .deleteMeeting: return .delete
         }
     }
     
@@ -71,6 +76,8 @@ extension MeetingAPI: BaseAPI {
             if let memo = requestModel.memo {
                 params["memo"] = memo
             }
+        case .deleteMeeting(let meetingID, _):
+            params["meetingId"] = meetingID
         }
         
         return params
@@ -78,8 +85,10 @@ extension MeetingAPI: BaseAPI {
     
     private var parameterEncoding: ParameterEncoding {
         switch self {
-        case .createMeeting: return JSONEncoding.default
-        default: return JSONEncoding.default
+        case .createMeeting:
+            return JSONEncoding.default
+        case .meetingList, .meetingDetail, .deleteMeeting:
+            return ParameterEncodingWithNoSlash.init()
         }
     }
     
@@ -87,17 +96,7 @@ extension MeetingAPI: BaseAPI {
     
     var task: Moya.Task {
         switch self {
-        case .meetingList:
-            return .requestParameters(
-                parameters: bodyParameters ?? [:],
-                encoding: ParameterEncodingWithNoSlash()
-            )
-        case .meetingDetail:
-            return .requestParameters(
-                parameters: bodyParameters ?? [:],
-                encoding: ParameterEncodingWithNoSlash()
-            )
-        case .createMeeting:
+        case .meetingList, .meetingDetail, .createMeeting, .deleteMeeting:
             return .requestParameters(
                 parameters: bodyParameters ?? [:],
                 encoding: parameterEncoding

--- a/Baggle/Baggle/Core/API/MemberAPI.swift
+++ b/Baggle/Baggle/Core/API/MemberAPI.swift
@@ -14,6 +14,7 @@ enum MemberAPI {
     case fetchMeetingInfo(meetingID: Int, token: String)
     case postJoinMeeting(meetingID: Int, token: String)
     case delegateOwner(fromMemberID: Int, toMemberID: Int, token: String)
+    case leaveMeeting(memberID: Int, token: String)
 }
 
 extension MemberAPI: BaseAPI {
@@ -27,6 +28,7 @@ extension MemberAPI: BaseAPI {
         case .fetchMeetingInfo: return ""
         case .postJoinMeeting: return "participation"
         case .delegateOwner: return "delegate"
+        case .leaveMeeting: return "leave"
         }
     }
     
@@ -40,6 +42,8 @@ extension MemberAPI: BaseAPI {
             return HeaderType.jsonWithBearer(token: token).value
         case .delegateOwner(_, _, let token):
             return HeaderType.jsonWithBearer(token: token).value
+        case .leaveMeeting(_, let token):
+            return HeaderType.jsonWithBearer(token: token).value
         }
     }
     
@@ -50,6 +54,7 @@ extension MemberAPI: BaseAPI {
         case .fetchMeetingInfo: return .get
         case .postJoinMeeting: return .post
         case .delegateOwner: return .patch
+        case .leaveMeeting: return .patch
         }
     }
     
@@ -66,6 +71,8 @@ extension MemberAPI: BaseAPI {
         case let .delegateOwner(fromMemberID, toMemberID, _):
             params["fromMemberId"] = fromMemberID
             params["toMemberId"] = toMemberID
+        case .leaveMeeting(let memberID, _):
+            params["memberId"] = memberID
         }
         
         return params
@@ -73,12 +80,10 @@ extension MemberAPI: BaseAPI {
     
     private var parameterEncoding: ParameterEncoding {
         switch self {
-        case .fetchMeetingInfo:
+        case .fetchMeetingInfo, .delegateOwner, .leaveMeeting:
             return ParameterEncodingWithNoSlash.init()
         case .postJoinMeeting:
             return JSONEncoding.default
-        case .delegateOwner:
-            return ParameterEncodingWithNoSlash.init()
         }
     }
     
@@ -86,7 +91,7 @@ extension MemberAPI: BaseAPI {
     
     var task: Task {
         switch self {
-        case .fetchMeetingInfo, .postJoinMeeting, .delegateOwner:
+        case .fetchMeetingInfo, .postJoinMeeting, .delegateOwner, .leaveMeeting:
             return .requestParameters(
                 parameters: bodyParameters ?? [:],
                 encoding: parameterEncoding

--- a/Baggle/Baggle/Core/Models/Alert/Home/MeetingDetail/AlertMeetingDetailType.swift
+++ b/Baggle/Baggle/Core/Models/Alert/Home/MeetingDetail/AlertMeetingDetailType.swift
@@ -22,8 +22,6 @@ enum AlertMeetingDetailType: Equatable {
     case userError // 유저 에러
     case invitation
     case invalidAuthentication // 유효하지 않는 긴급 버튼 인증 시간
-
-    case delete
 }
 
 extension AlertMeetingDetailType: AlertType {
@@ -40,7 +38,7 @@ extension AlertMeetingDetailType: AlertType {
                 .meetingDelegateFail,
                 .meetingDelegateSuccess:
             return .one
-        case .delete, .meetingDelete:
+        case .meetingDelete:
             return .two(.destructive)
         case .meetingLeave:
             return .two(.none)
@@ -63,7 +61,6 @@ extension AlertMeetingDetailType: AlertType {
         case .userError: return "유저 정보 에러"
         case .invitation: return "초대"
         case .invalidAuthentication: return "인증 가능한 시간이 아니에요."
-        case .delete: return "정말 방을 폭파하시겠어요?"
         }
     }
     
@@ -83,7 +80,6 @@ extension AlertMeetingDetailType: AlertType {
         case .userError: return "유저 정보를 불러오는데 에러가 발생했어요. 재로그인해주세요."
         case .invitation: return "초대를 할 수가 없어요."
         case .invalidAuthentication: return "인증 가능한 시간에 다시 시도해주세요."
-        case .delete: return "입력하신 약속정보는 모두 삭제돼요!"
         }
     }
     
@@ -103,7 +99,6 @@ extension AlertMeetingDetailType: AlertType {
         case .userError: return "재로그인"
         case .invitation: return "확인"
         case .invalidAuthentication: return "확인"
-        case .delete: return "폭파하기"
         }
     }
 }

--- a/Baggle/Baggle/Core/Models/Alert/Home/MeetingDetail/AlertMeetingDetailType.swift
+++ b/Baggle/Baggle/Core/Models/Alert/Home/MeetingDetail/AlertMeetingDetailType.swift
@@ -18,6 +18,8 @@ enum AlertMeetingDetailType: Equatable {
     
     case meetingLeave // 모임 나가기 (방장 아닌 사람)
     
+    case invalidMeetingDelete // 모임 확정 이후에는 폭파, 넘기기, 나가기 불가
+    
     case networkError(String) // 네트워크 에러
     case userError // 유저 에러
     case invitation
@@ -36,7 +38,9 @@ extension AlertMeetingDetailType: AlertType {
                 .invalidAuthentication,
                 .meetingUnwrapping,
                 .meetingDelegateFail,
-                .meetingDelegateSuccess:
+                .meetingDelegateSuccess,
+                .invalidMeetingDelete
+            :
             return .one
         case .meetingDelete:
             return .two(.destructive)
@@ -57,6 +61,8 @@ extension AlertMeetingDetailType: AlertType {
             
         case .meetingLeave: return "정말 방을 나가시겠어요?"
             
+        case .invalidMeetingDelete: return "모임 나가기 불가"
+            
         case .networkError: return "네트워크 에러"
         case .userError: return "유저 정보 에러"
         case .invitation: return "초대"
@@ -76,6 +82,8 @@ extension AlertMeetingDetailType: AlertType {
             
         case .meetingLeave: return "이 약속 방의 모든 정보가 사라져요."
             
+        case .invalidMeetingDelete: return "약속이 확정된 이후에는 모임을 나갈 수 없어요."
+            
         case .networkError(let error): return "네트워크 에러가 발생했어요. 잠시 후 다시 시도해주세요. \(error)"
         case .userError: return "유저 정보를 불러오는데 에러가 발생했어요. 재로그인해주세요."
         case .invitation: return "초대를 할 수가 없어요."
@@ -94,6 +102,8 @@ extension AlertMeetingDetailType: AlertType {
         case .meetingDelegateSuccess: return "홈으로"
             
         case .meetingLeave: return "나가기"
+            
+        case .invalidMeetingDelete: return "확인"
             
         case .networkError: return "확인"
         case .userError: return "재로그인"

--- a/Baggle/Baggle/Core/Models/Alert/Home/MeetingDetail/AlertMeetingDetailType.swift
+++ b/Baggle/Baggle/Core/Models/Alert/Home/MeetingDetail/AlertMeetingDetailType.swift
@@ -16,6 +16,8 @@ enum AlertMeetingDetailType: Equatable {
     case meetingDelegateFail // 방장 넘기기 불가
     case meetingDelegateSuccess // 방장 넘기기 성공
     
+    case meetingLeave // 모임 나가기 (방장 아닌 사람)
+    
     case networkError(String) // 네트워크 에러
     case userError // 유저 에러
     case invitation
@@ -40,6 +42,8 @@ extension AlertMeetingDetailType: AlertType {
             return .one
         case .delete, .meetingDelete:
             return .two(.destructive)
+        case .meetingLeave:
+            return .two(.none)
         }
     }
     
@@ -48,9 +52,13 @@ extension AlertMeetingDetailType: AlertType {
         case .meetingNotFound: return "해당하는 모임이 없어요"
         case .meetingIDError: return "모임 정보가 없어요"
         case .meetingUnwrapping: return "모임 정보 에러"
+            
         case .meetingDelete: return "정말 방을 폭파하시겠어요?"
         case .meetingDelegateFail: return "방장 넘기기 불가"
         case .meetingDelegateSuccess: return "방장 넘기기 성공"
+            
+        case .meetingLeave: return "정말 방을 나가시겠어요?"
+            
         case .networkError: return "네트워크 에러"
         case .userError: return "유저 정보 에러"
         case .invitation: return "초대"
@@ -64,9 +72,13 @@ extension AlertMeetingDetailType: AlertType {
         case .meetingNotFound: return "서버에서 모임을 찾을 수 없어요."
         case .meetingIDError: return "홈에서 모임 정보를 전달하는데 실패했어요."
         case .meetingUnwrapping: return "모임 정보를 불러오는데 실패했어요. [언래핑]"
+            
         case .meetingDelegateFail: return "혼자 있을 때는 방장을 넘길 수 없어요."
         case .meetingDelegateSuccess: return "방장을 성공적으로 넘겼어요!"
         case .meetingDelete: return "입력하신 약속정보는 모두 삭제돼요!"
+            
+        case .meetingLeave: return "이 약속 방의 모든 정보가 사라져요."
+            
         case .networkError(let error): return "네트워크 에러가 발생했어요. 잠시 후 다시 시도해주세요. \(error)"
         case .userError: return "유저 정보를 불러오는데 에러가 발생했어요. 재로그인해주세요."
         case .invitation: return "초대를 할 수가 없어요."
@@ -80,9 +92,13 @@ extension AlertMeetingDetailType: AlertType {
         case .meetingNotFound: return "돌아가기"
         case .meetingIDError: return "돌아가기"
         case .meetingUnwrapping: return "확인"
+            
         case .meetingDelete: return "방 폭파하기"
         case .meetingDelegateFail: return "확인"
         case .meetingDelegateSuccess: return "홈으로"
+            
+        case .meetingLeave: return "나가기"
+            
         case .networkError: return "확인"
         case .userError: return "재로그인"
         case .invitation: return "확인"

--- a/Baggle/Baggle/Core/Models/Meeting/MeetingDetail/MeetingDetail.swift
+++ b/Baggle/Baggle/Core/Models/Meeting/MeetingDetail/MeetingDetail.swift
@@ -17,6 +17,7 @@ struct MeetingDetail: Equatable {
     let memo: String? // 메모
     let members: [Member] // 참여자 정보
     let memberID: Int // 모임 내 본인의 멤버id
+    let isOwner: Bool // 모임 내 방장여부
     let stampStatus: MeetingStampStatus // 제목 옆에 들어가는 약속 도장
     let emergencyStatus: MeetingEmergencyStatus // 긴급 버튼 상태
     let isEmergencyAuthority: Bool // 내가 긴급 버튼 권한자
@@ -46,6 +47,7 @@ extension MeetingDetail {
             memo: memo,
             members: members,
             memberID: memberID,
+            isOwner: isOwner,
             stampStatus: stampStatus,
             emergencyStatus: .onGoing,
             isEmergencyAuthority: isEmergencyAuthority,
@@ -75,6 +77,7 @@ extension MeetingDetail {
             memo: self.memo,
             members: updatedMembers,
             memberID: self.memberID,
+            isOwner: self.isOwner,
             stampStatus: self.stampStatus,
             emergencyStatus: .termination,
             isEmergencyAuthority: self.isEmergencyAuthority,

--- a/Baggle/Baggle/Core/Models/Network/MeetingDetail/MeetingDetailEntity.swift
+++ b/Baggle/Baggle/Core/Models/Network/MeetingDetail/MeetingDetailEntity.swift
@@ -34,6 +34,7 @@ extension MeetingDetailEntity {
             memo: (memo ?? "").isEmpty ? nil : memo,
             members: members.map { $0.memberDomain(afterMeetingConfirmed: isMeetingConfirmed()) },
             memberID: memberId(username: username, members: members),
+            isOwner: isOwner(username: username, members: members),
             stampStatus: status.meetingStampStatus(),
             emergencyStatus: status.meetingEmergencyStatus(),
             isEmergencyAuthority: isEmergencyAuthority(username: username, members: self.members),
@@ -56,6 +57,10 @@ extension MeetingDetailEntity {
         return members.filter({ $0.nickname == username }).first?.memberID ?? -1
     }
 
+    private func isOwner(username: String, members: [MeetingDetailMemberEntity]) -> Bool {
+        return members.contains { $0.nickname == username && $0.meetingAuthority }
+    }
+    
     private func isEmergencyAuthority(
         username: String,
         members: [MeetingDetailMemberEntity]

--- a/Baggle/Baggle/Core/Services/Common/NetworkService.swift
+++ b/Baggle/Baggle/Core/Services/Common/NetworkService.swift
@@ -105,6 +105,8 @@ extension NetworkService {
         case 400:
             if message == "잘못된 요청입니다." {
                 return APIError.duplicatedMeeting
+            } else if message == "유효하지 않은 모임 시간입니다." {
+                return APIError.invalidMeetingDeleteTime
             }
             return APIError.badRequest
         case 401:

--- a/Baggle/Baggle/Core/Services/Error/APIError.swift
+++ b/Baggle/Baggle/Core/Services/Error/APIError.swift
@@ -8,18 +8,40 @@
 import Foundation
 
 enum APIError: Error, Equatable {
+    
+    // MARK: - 400
+    
     case badRequest // 400
     case duplicatedMeeting // 400, 모임 2시간 전후 일정 존재
+    case invalidMeetingDeleteTime // 400 모임 확정 이후 나갈 수 없음 (모임 확정 됨)
+    
+    // MARK: - 401
+    
     case unauthorized // 401, 토큰 에러
+    
+    // MARK: - 403
+    
     case limitMeetingCount // 403, 모임 생성 최대 개수 초과
     case exceedMemberCount // 403, 모임 참여 가능 인원 초과
     case forbidden // 403, 리소스 접근 제한
+    
+    // MARK: - 404
+    
     case notFound // 404, 리소스 또는 유저 정보 없음
+    
+    // MARK: - 409
+    
     case duplicatedUser // 409, 이미 존재하는 회원
     case duplicatedNickname // 409, 닉네임 중복
     case duplicatedJoinMeeting // 409, 이미 참여한 약속
     case expiredMeeting // 만료된 약속
+
+    // MARK: - 500
+    
     case server // 500
+
+    // MARK: - 그외
+    
     case network // 네트워크 에러
     case decoding // 디코딩 에러
     case jsonEncodingError // Encoding 에러
@@ -30,18 +52,40 @@ enum APIError: Error, Equatable {
 extension APIError: LocalizedError {
     public var errorDescription: String? {
         switch self {
+            // MARK: - 400
+            
         case .badRequest: return "400 에러"
         case .duplicatedMeeting: return "모임 2시간 전후 일정 존재"
+        case .invalidMeetingDeleteTime: return "모임 확정 이후 나갈 수 없음"
+        
+            
+            // MARK: - 401
+            
         case .unauthorized: return "401 에러"
+            
+            // MARK: - 403
+            
         case .limitMeetingCount: return "모임 2시간 전후 생성 불가"
         case .exceedMemberCount: return "모임 참여 가능 인원 초과"
         case .forbidden: return "403 에러"
+            
+            // MARK: - 404
+            
         case .notFound: return "404 에러"
+            
+            // MARK: - 409
+            
         case .duplicatedUser: return "409 에러"
         case .duplicatedNickname: return "409 에러"
         case .duplicatedJoinMeeting: return "409 에러"
         case .expiredMeeting: return "만료된 약속"
+            
+            // MARK: - 500
+            
         case .server: return "500 서버 에러"
+            
+            // MARK: - 그외
+            
         case .network: return "네트워크 에러"
         case .decoding: return "디코딩 에러"
         case .jsonEncodingError: return "인코딩 에러"

--- a/Baggle/Baggle/Core/Services/Login/LoginService.swift
+++ b/Baggle/Baggle/Core/Services/Login/LoginService.swift
@@ -31,7 +31,10 @@ extension LoginService: DependencyKey {
                 )
                 
                 let user = data.toDomain()
-                let token = UserToken(accessToken: data.accessToken, refreshToken: data.refreshToken)
+                let token = UserToken(
+                    accessToken: data.accessToken,
+                    refreshToken: data.refreshToken
+                )
                 try UserManager.shared.save(user: user, userToken: token)
                 
                 return .success

--- a/Baggle/Baggle/Core/Services/Meeting/MeetingDelete/MeetingDeleteResult.swift
+++ b/Baggle/Baggle/Core/Services/Meeting/MeetingDelete/MeetingDeleteResult.swift
@@ -12,6 +12,8 @@ enum MeetingDeleteResult {
     case successLeave // 방장 아닌 사람이 나가기 성공
     case successDelete // 방장이 모임 폭파 성공
 
+    case invalidDeleteTime // 모임 확정 이후 폭파, 위임, 나가기 불가
+    
     case networkError
     case expiredToken
     case userError

--- a/Baggle/Baggle/Core/Services/Meeting/MeetingDelete/MeetingDeleteResult.swift
+++ b/Baggle/Baggle/Core/Services/Meeting/MeetingDelete/MeetingDeleteResult.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum MeetingDeleteResult {
     case successDelegate
+    case successLeave
     case networkError
     case expiredToken
     case userError

--- a/Baggle/Baggle/Core/Services/Meeting/MeetingDelete/MeetingDeleteResult.swift
+++ b/Baggle/Baggle/Core/Services/Meeting/MeetingDelete/MeetingDeleteResult.swift
@@ -8,8 +8,10 @@
 import Foundation
 
 enum MeetingDeleteResult {
-    case successDelegate
-    case successLeave
+    case successDelegate // 방장 위임 성공
+    case successLeave // 방장 아닌 사람이 나가기 성공
+    case successDelete // 방장이 모임 폭파 성공
+
     case networkError
     case expiredToken
     case userError

--- a/Baggle/Baggle/Core/Services/Meeting/MeetingDelete/MeetingDeleteService.swift
+++ b/Baggle/Baggle/Core/Services/Meeting/MeetingDelete/MeetingDeleteService.swift
@@ -36,6 +36,9 @@ extension MeetingDeleteService: DependencyKey {
             
             return .successDelegate
         } catch {
+            if let apiError = error as? APIError, apiError == .invalidMeetingDeleteTime {
+                return .invalidDeleteTime
+            }
             return .networkError
         }
     } leave: { memberID in
@@ -53,6 +56,10 @@ extension MeetingDeleteService: DependencyKey {
             
             return .successLeave
         } catch {
+            if let apiError = error as? APIError, apiError == .invalidMeetingDeleteTime {
+                return .invalidDeleteTime
+            }
+            
             return .networkError
         }
     } delete: { meetingID in
@@ -70,6 +77,10 @@ extension MeetingDeleteService: DependencyKey {
             
             return .successDelete
         } catch {
+            if let apiError = error as? APIError, apiError == .invalidMeetingDeleteTime {
+                return .invalidDeleteTime
+            }
+            
             return .networkError
         }
     }

--- a/Baggle/Baggle/Core/Services/Meeting/MeetingDelete/MeetingDeleteService.swift
+++ b/Baggle/Baggle/Core/Services/Meeting/MeetingDelete/MeetingDeleteService.swift
@@ -22,39 +22,44 @@ extension MeetingDeleteService: DependencyKey {
     
     static var liveValue = Self { fromMemberID, toMemberID in
         do {
-            guard let accessToken = UserManager.shared.accessToken else {
-                return .userError
-            }
-            
-            try await networkMemberService.requestWithNoResult(
-                .delegateOwner(
-                    fromMemberID: fromMemberID,
-                    toMemberID: toMemberID,
-                    token: accessToken
+            return try await Task.retrying {
+                guard let accessToken = UserManager.shared.accessToken else {
+                    return .userError
+                }
+                
+                try await networkMemberService.requestWithNoResult(
+                    .delegateOwner(
+                        fromMemberID: fromMemberID,
+                        toMemberID: toMemberID,
+                        token: accessToken
+                    )
                 )
-            )
-            
-            return .successDelegate
+                
+                return .successDelegate
+            }.value
         } catch {
             if let apiError = error as? APIError, apiError == .invalidMeetingDeleteTime {
                 return .invalidDeleteTime
             }
+            
             return .networkError
         }
     } leave: { memberID in
         do {
-            guard let accessToken = UserManager.shared.accessToken else {
-                return .userError
-            }
-            
-            try await networkMemberService.requestWithNoResult(
-                .leaveMeeting(
-                    memberID: memberID,
-                    token: accessToken
+            return try await Task.retrying {
+                guard let accessToken = UserManager.shared.accessToken else {
+                    return .userError
+                }
+                
+                try await networkMemberService.requestWithNoResult(
+                    .leaveMeeting(
+                        memberID: memberID,
+                        token: accessToken
+                    )
                 )
-            )
-            
-            return .successLeave
+                
+                return .successLeave
+            }.value
         } catch {
             if let apiError = error as? APIError, apiError == .invalidMeetingDeleteTime {
                 return .invalidDeleteTime
@@ -64,18 +69,20 @@ extension MeetingDeleteService: DependencyKey {
         }
     } delete: { meetingID in
         do {
-            guard let accessToken = UserManager.shared.accessToken else {
-                return .userError
-            }
-            
-            try await networkMeetingService.requestWithNoResult(
-                .deleteMeeting(
-                    meetingID: meetingID,
-                    token: accessToken
+            return try await Task.retrying {
+                guard let accessToken = UserManager.shared.accessToken else {
+                    return .userError
+                }
+                
+                try await networkMeetingService.requestWithNoResult(
+                    .deleteMeeting(
+                        meetingID: meetingID,
+                        token: accessToken
+                    )
                 )
-            )
-            
-            return .successDelete
+                
+                return .successDelete
+            }.value
         } catch {
             if let apiError = error as? APIError, apiError == .invalidMeetingDeleteTime {
                 return .invalidDeleteTime

--- a/Baggle/Baggle/Core/Services/Meeting/MeetingDelete/MeetingDeleteService.swift
+++ b/Baggle/Baggle/Core/Services/Meeting/MeetingDelete/MeetingDeleteService.swift
@@ -11,6 +11,7 @@ import ComposableArchitecture
 
 struct MeetingDeleteService {
     var delegateOwner: (_ fromMemberID: Int, _ toMemberID: Int) async -> MeetingDeleteResult
+    var leave: (_ memberID: Int) async -> MeetingDeleteResult
 }
 
 extension MeetingDeleteService: DependencyKey {
@@ -32,6 +33,23 @@ extension MeetingDeleteService: DependencyKey {
             )
             
             return .successDelegate
+        } catch {
+            return .networkError
+        }
+    } leave: { memberID in
+        do {
+            guard let accessToken = UserManager.shared.accessToken else {
+                return .userError
+            }
+            
+            try await networkService.requestWithNoResult(
+                .leaveMeeting(
+                    memberID: memberID,
+                    token: accessToken
+                )
+            )
+            
+            return .successLeave
         } catch {
             return .networkError
         }

--- a/Baggle/Baggle/Core/Services/Meeting/MeetingDelete/MeetingDeleteService.swift
+++ b/Baggle/Baggle/Core/Services/Meeting/MeetingDelete/MeetingDeleteService.swift
@@ -12,11 +12,13 @@ import ComposableArchitecture
 struct MeetingDeleteService {
     var delegateOwner: (_ fromMemberID: Int, _ toMemberID: Int) async -> MeetingDeleteResult
     var leave: (_ memberID: Int) async -> MeetingDeleteResult
+    var delete: (_ meetingID: Int) async -> MeetingDeleteResult
 }
 
 extension MeetingDeleteService: DependencyKey {
     
-    static let networkService = NetworkService<MemberAPI>()
+    static let networkMemberService = NetworkService<MemberAPI>()
+    static let networkMeetingService = NetworkService<MeetingAPI>()
     
     static var liveValue = Self { fromMemberID, toMemberID in
         do {
@@ -24,7 +26,7 @@ extension MeetingDeleteService: DependencyKey {
                 return .userError
             }
             
-            try await networkService.requestWithNoResult(
+            try await networkMemberService.requestWithNoResult(
                 .delegateOwner(
                     fromMemberID: fromMemberID,
                     toMemberID: toMemberID,
@@ -42,7 +44,7 @@ extension MeetingDeleteService: DependencyKey {
                 return .userError
             }
             
-            try await networkService.requestWithNoResult(
+            try await networkMemberService.requestWithNoResult(
                 .leaveMeeting(
                     memberID: memberID,
                     token: accessToken
@@ -50,6 +52,23 @@ extension MeetingDeleteService: DependencyKey {
             )
             
             return .successLeave
+        } catch {
+            return .networkError
+        }
+    } delete: { meetingID in
+        do {
+            guard let accessToken = UserManager.shared.accessToken else {
+                return .userError
+            }
+            
+            try await networkMeetingService.requestWithNoResult(
+                .deleteMeeting(
+                    meetingID: meetingID,
+                    token: accessToken
+                )
+            )
+            
+            return .successDelete
         } catch {
             return .networkError
         }

--- a/Baggle/Baggle/DesignSystem/View/Alert/BaggleAlert.swift
+++ b/Baggle/Baggle/DesignSystem/View/Alert/BaggleAlert.swift
@@ -67,7 +67,7 @@ struct BaggleAlert_Previews: PreviewProvider {
             
             BaggleAlert(
                 isPresented: .constant(true),
-                alertType: AlertMeetingDetailType.delete
+                alertType: AlertMeetingDetailType.meetingDelete
             ) {
                 print("눌렀어")
             }

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailFeature.swift
@@ -208,6 +208,8 @@ struct MeetingDetailFeature: ReducerProtocol {
                     return .run { send in await send(.alertTypeChanged(.meetingDelegateSuccess))}
                 case .successLeave, .successDelete:
                     return .run { send in await send(.delegate(.deleteSuccess))}
+                case .invalidDeleteTime:
+                    return .run { send in await send(.alertTypeChanged(.invalidMeetingDelete))}
                 case .networkError:
                     return .run { send in await send(.alertTypeChanged(.networkError("네트워크 에러")))}
                 case .expiredToken:
@@ -366,7 +368,7 @@ struct MeetingDetailFeature: ReducerProtocol {
                 switch alertType {
                 case .meetingNotFound, .meetingIDError:
                     return .run { send in await send(.delegate(.onDisappear))}
-                case .networkError, .invalidAuthentication, .meetingUnwrapping, .meetingDelegateFail:
+                case .networkError, .invalidAuthentication, .meetingUnwrapping:
                     return .none
                 case .userError:
                     return .run { send in await send(.delegate(.moveToLogin))}
@@ -378,6 +380,8 @@ struct MeetingDetailFeature: ReducerProtocol {
                     return .run { send in await send(.delegate(.deleteSuccess)) }
                 case .meetingLeave: // 모임 나가기 (방장 아닌 사람)
                     return .run { send in await send(.leaveMeeting)}
+                case .meetingDelegateFail, .invalidMeetingDelete:
+                    return .none
                 }
 
                 // Action Sheet

--- a/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/MeetingDetailView.swift
@@ -118,24 +118,34 @@ struct MeetingDetailView: View {
                         send: { MeetingDetailFeature.Action.presentActionSheet($0) }
                     ),
                 content: {
-                    Text("방 정보 수정하기")
-                        .addAction {
-                            viewStore.send(.inviteButtonTapped)
-                        }
                     
-                    Divider().padding(.horizontal, 20)
-                    
-                    Text("방장 넘기고 나가기")
-                        .addAction {
-                            viewStore.send(.leaveButtonTapped)
-                        }
-                    
-                    Divider().padding(.horizontal, 20)
-                    
-                    Text("방 폭파하기")
-                        .addAction({
-                            viewStore.send(.deleteButtonTapped)
-                        }, role: .destructive)
+                    if let meetingData = viewStore.meetingData, meetingData.isOwner {
+                        Text("방 정보 수정하기")
+                            .addAction {
+                                viewStore.send(.inviteButtonTapped)
+                            }
+                        
+                        Divider().padding(.horizontal, 20)
+                        
+                        Text("방장 넘기고 나가기")
+                            .addAction {
+                                viewStore.send(.delegateButtonTapped)
+                            }
+                        
+                        Divider().padding(.horizontal, 20)
+                        
+                        Text("방 폭파하기")
+                            .addAction({
+                                viewStore.send(.deleteButtonTapped)},
+                                role: .destructive
+                            )
+                    } else {
+                        Text("방 나가기")
+                            .addAction({
+                                viewStore.send(.leaveButtonTapped)},
+                                role: .destructive
+                            )
+                    }
             })
             .sheet(
                 store: self.store.scope(


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 

- close #226 
- close #227 
- close #239 

## 내용
<!--
로직 설명  
--> 

- 모임 나가기 = leave, 모임 폭파 = delte, 모임 위임 = delegate 라는 용어를 사용합니다.
- 모임 나가기 구현했습니다. `MemberAPI`와 `Meeting Delete Service` - `leave` 함수 참고해주세요.
- 모임 폭파 구현했습니다. `MeetingAPI`와 `Meeting Delete Service` - `delete` 함수 참고해주세요.
- 방장 여부에 따른 Action Sheet 분기처리를 합니다. 
  `Meeting Detail Entity` -> `Meeting Detail` 변환시 isOwner 프로퍼티를 생성합니다.
- 모임 확정 이후에 나가기, 위임, 폭파가 불가능한 것 처리했습니다. (400 에러 -> Alert)


### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

- Action Sheet 분기 처리

|방장|방장 x|
|:---:|:---:|
|<img width = 300 src = "https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/ffb8de63-89ef-4029-a4e9-4d13e22e6ca4" />|<img width = 300 src = "https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/de828d53-c9c9-4b57-9616-84fe17411bba" />|

- 모임 나가기 

https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/334cff3f-9429-4c92-bd44-f22fb5bdee1b

영상에서는 홈 refresh 안 됬는데, 영상 촬영이후 홈 리프레시까지 설정했습니다.

- 방 폭파하기


https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/61cb0aa2-0948-4bbe-aa24-8dad3d4f4c3d


알람도 잘 옵니다.

<img width = 300 src = "https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/12062f3e-2588-4bc8-8e65-43344f2ec8e8" />

- 모임 확정 이후 실패 Alert

![Simulator Screen Recording - iPhone 14 Pro - 2023-09-08 at 20 05 49](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/a088d827-da78-481e-bbc1-0d5da5cf15fc)



## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
