### PR TITLE
Fix - 로그아웃 후 재로그인시 유저 정보 에러 뜨는 문제 해결

### DIFF
--- a/Baggle/Baggle/Core/Models/Alert/Tab/AlertMainTabType.swift
+++ b/Baggle/Baggle/Core/Models/Alert/Tab/AlertMainTabType.swift
@@ -37,7 +37,8 @@ extension AlertMainTabType: AlertType {
         switch self {
         case .logout: return "로그아웃을 해도 입력한\n약속 정보는 사라지지 않아요!"
         case .withdraw: return "입력하신 개인정보와\n약속정보는 모두 삭제돼요!"
-        case .networkError(let description): return "네트워크 에러가 발생했어요.\n잠시 후 다시 시도해주세요. \(description)"
+        case .networkError(let description):
+            return "네트워크 에러가 발생했어요.\n잠시 후 다시 시도해주세요. \(description)"
         case .userError: return "로컬에 유저 정보 저장 중 에러가 발생했어요.\n로그인 후 다시 시도해주세요."
         }
     }

--- a/Baggle/Baggle/Features/App/AppFeature.swift
+++ b/Baggle/Baggle/Features/App/AppFeature.swift
@@ -47,6 +47,11 @@ struct AppFeature: ReducerProtocol {
 
             case .login(.delegate(.moveToMainTab)):
                 state.isLoggedIn = true
+                state.mainTabFeature = MainTabFeature.State(
+                    selectedTab: .home,
+                    homeFeature: HomeFeature.State(),
+                    myPageFeature: MyPageFeature.State()
+                )
                 return .none
 
             case .login:
@@ -57,11 +62,6 @@ struct AppFeature: ReducerProtocol {
             case .mainTab(.delegate(.moveToLogin)):
                 UserManager.shared.delete()
                 state.isLoggedIn = false
-                state.mainTabFeature = MainTabFeature.State(
-                    selectedTab: .home,
-                    homeFeature: HomeFeature.State(),
-                    myPageFeature: MyPageFeature.State()
-                )
                 return .none
 
             case .mainTab:

--- a/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
@@ -74,7 +74,8 @@ struct HomeFeature: ReducerProtocol {
 
             switch action {
             case .onAppear:
-                state.user = UserManager.shared.user ?? User.error()
+                guard let user = UserManager.shared.user else { return .none }
+                state.user = user
                 if state.progressList.isEmpty && state.completedList.isEmpty {
                     return .run { send in
                         await send(.fetchMeetingList(.scheduled))

--- a/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
+++ b/Baggle/Baggle/Features/Tab/Home/HomeFeature.swift
@@ -74,7 +74,10 @@ struct HomeFeature: ReducerProtocol {
 
             switch action {
             case .onAppear:
-                guard let user = UserManager.shared.user else { return .none }
+                guard let user = UserManager.shared.user else {
+                    return .run { send in await send(.changeHomeStatus(.error)) }
+                }
+                
                 state.user = user
                 if state.progressList.isEmpty && state.completedList.isEmpty {
                     return .run { send in

--- a/Baggle/Baggle/Features/Tab/MainTab/MainTabView.swift
+++ b/Baggle/Baggle/Features/Tab/MainTab/MainTabView.swift
@@ -23,7 +23,7 @@ struct MainTabView: View {
         NavigationStackStore(self.store.scope(
             state: \.path,
             action: { .path($0)})
-        )  {
+        ) {
             WithViewStore(self.store, observe: { $0 }) { viewStore in
                 ZStack {
                     TabView(


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
close #250 

## 내용
<!--
로직 설명  
--> 

마이페이지에서 로그아웃을 하고나면, HomeView의 onAppear이 호출되면서 전체 모임 조회(meetingList)가 호출되었고
로그아웃된 상태라 정상적인 유저 정보를 갖지 않고 통신하기 때문에 유저 정보 에러가 발생하며 로그인 후에는 이미 발생했던 AlertMainTabType의 userError가 떠있는 상태로 보여졌습니다.

- 로그아웃 후 로그인 화면이 보여질때 HomeView의 onAppear이 호출되는데, 이때 유저 정보가 없으면 user.error()를 넣어주지 않고 homeStatus를 error로 바꾸도록 했습니다.
- 로그인 뷰가 보여진 상태이고, 로그인 성공하면 HomeView의 onAppear이 다시 호출되며 정상적인 서버 통신이 이루어지기 때문에 사실상 homeStatus가 error인 경우가 보일 일은 없습니다.
- alert를 띄우면 alert가 그대로 남아있고 재로그인밖에 답이 없기 때문에 뷰의 상태를 잠시 바꿔두는거로 했습니다.


### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 
![ezgif com-resize (1)](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/1fed15e8-4d3f-4bf9-9b14-c45d976ca9a0)



## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

근본적인 문제가 마이페이지에서 로그아웃했을때 HomeView의 onappear이 호출되는 문제인 것 같은데
혹시 예상되는 이유가 있으실까요?🤔 
이것저것 찾아보다가 안보여서 일단은 현재처럼 수정했습니다

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
