### PR TITLE
Fix - 모임 상세 인증 후 다른 참여자 탈락으로 뜨는 문제 해결

### DIFF
--- a/Baggle/Baggle/Core/API/MeetingAPI.swift
+++ b/Baggle/Baggle/Core/API/MeetingAPI.swift
@@ -42,7 +42,7 @@ extension MeetingAPI: BaseAPI {
             return HeaderType.jsonWithBearer(token: token).value
         case .createMeeting(_, let token):
             return HeaderType.jsonWithBearer(token: token).value
-        case .deleteMeeting(_ , let token):
+        case .deleteMeeting(_, let token):
             return HeaderType.jsonWithBearer(token: token).value
         }
     }

--- a/Baggle/Baggle/Core/Models/Meeting/MeetingDetail/MeetingDetail.swift
+++ b/Baggle/Baggle/Core/Models/Meeting/MeetingDetail/MeetingDetail.swift
@@ -63,7 +63,6 @@ extension MeetingDetail {
     // emergencyStatus -> .terminattion으로 변경
     
     func updateFeed(_ feed: Feed) -> MeetingDetail {
-        
         let updatedMembers = self.members.map {
             return $0.id == self.memberID ? $0.updateFeed(certImage: feed.feedImageURL) : $0
         }
@@ -79,7 +78,7 @@ extension MeetingDetail {
             memberID: self.memberID,
             isOwner: self.isOwner,
             stampStatus: self.stampStatus,
-            emergencyStatus: .termination,
+            emergencyStatus: self.emergencyStatus,
             isEmergencyAuthority: self.isEmergencyAuthority,
             emergencyButtonActive: self.emergencyButtonActive,
             emergencyButtonActiveTime: self.emergencyButtonActiveTime,

--- a/Baggle/Baggle/Core/Models/Network/Feed/FeedPhotoEntity.swift
+++ b/Baggle/Baggle/Core/Models/Network/Feed/FeedPhotoEntity.swift
@@ -28,4 +28,3 @@ extension FeedPhotoEntity {
         )
     }
 }
-

--- a/Baggle/Baggle/Core/Models/Network/MeetingStatus/MeetingStatusEntity.swift
+++ b/Baggle/Baggle/Core/Models/Network/MeetingStatus/MeetingStatusEntity.swift
@@ -32,7 +32,7 @@ extension MeetingStatusEntity {
         }
     }
     
-    func meetingStampStatus(remainingDay: Int) ->  MeetingStampStatus {
+    func meetingStampStatus(remainingDay: Int) -> MeetingStampStatus {
         if self == .scheduled && remainingDay == 0 {
             return .dDay
         }

--- a/Baggle/Baggle/Core/Services/Camera/Camera.swift
+++ b/Baggle/Baggle/Core/Services/Camera/Camera.swift
@@ -367,7 +367,7 @@ extension Camera: AVCapturePhotoCaptureDelegate {
     // 사진 촬영 완료후 실행되는 메소드
     func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
 
-        if let error = error {
+        if error != nil {
             resultImageContinuation?.resume(throwing: CameraError.capture)
             return
         }

--- a/Baggle/Baggle/Features/App/AppFeature.swift
+++ b/Baggle/Baggle/Features/App/AppFeature.swift
@@ -46,12 +46,11 @@ struct AppFeature: ReducerProtocol {
             // Login Feature
 
             case .login(.delegate(.moveToMainTab)):
-                state.isLoggedIn = true
                 state.mainTabFeature = MainTabFeature.State(
-                    selectedTab: .home,
                     homeFeature: HomeFeature.State(),
                     myPageFeature: MyPageFeature.State()
                 )
+                state.isLoggedIn = true
                 return .none
 
             case .login:

--- a/Baggle/Baggle/Features/Camera/CameraView.swift
+++ b/Baggle/Baggle/Features/Camera/CameraView.swift
@@ -50,7 +50,6 @@ struct CameraView: View {
                         text: "시간이 초과되었습니다"
                     )
                 }
-                
             }
             .onAppear {
                 viewStore.send(.onAppear)

--- a/Baggle/Baggle/Features/MeetingDetail/SelectHost/MeetingLeaveMemberView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/SelectHost/MeetingLeaveMemberView.swift
@@ -36,7 +36,11 @@ struct MeetingLeaveMemberView: View {
 struct MeetingLeaveMemberView_Previews: PreviewProvider {
     static var previews: some View {
         MeetingLeaveMemberView(
-            meetingLeaveMember: MeetingLeaveMember(id: 1, name: "유탁", profileURL: "https://i.namu.wiki/i/OXmmnGpQrbZ_6dYNGRIrCQEkKqgHZhBwxBU-KmfbjLZVknsUN8iXU2jYzVWFQb4P9qbVVHKiM5SfCa1_DXGLlS58m7UthtaWsCTmHlHvyvl6FR2kGRSYhZZ6T4Nr9nAeBUKMJpMzFrF6U-jvpunjgQ.webp"),
+            meetingLeaveMember: MeetingLeaveMember(
+                id: 1,
+                name: "유탁",
+                // swiftlint:disable:next line_length
+                profileURL: "https://i.namu.wiki/i/OXmmnGpQrbZ_6dYNGRIrCQEkKqgHZhBwxBU-KmfbjLZVknsUN8iXU2jYzVWFQb4P9qbVVHKiM5SfCa1_DXGLlS58m7UthtaWsCTmHlHvyvl6FR2kGRSYhZZ6T4Nr9nAeBUKMJpMzFrF6U-jvpunjgQ.webp"),
             isSelected: true
         )
     }

--- a/Baggle/Baggle/Features/MeetingDetail/SelectHost/SelectOwnerView.swift
+++ b/Baggle/Baggle/Features/MeetingDetail/SelectHost/SelectOwnerView.swift
@@ -113,9 +113,18 @@ struct SelectOwnerView_Previews: PreviewProvider {
                 reducer: SelectOwnerFeature()
             ),
             meetingLeaveMember: [
-                MeetingLeaveMember(id: 1, name: "수빈", profileURL: "https://i.namu.wiki/i/OXmmnGpQrbZ_6dYNGRIrCQEkKqgHZhBwxBU-KmfbjLZVknsUN8iXU2jYzVWFQb4P9qbVVHKiM5SfCa1_DXGLlS58m7UthtaWsCTmHlHvyvl6FR2kGRSYhZZ6T4Nr9nAeBUKMJpMzFrF6U-jvpunjgQ.webp"),
-                MeetingLeaveMember(id: 2, name: "유탁", profileURL: "https://i.namu.wiki/i/KSlJDAdoBtpnTzmwMv8dt4fXffy8CzUt4mTrzEptnyuc3ZGD9V-Qh8GNX_C7D6NSiwxl5n6aKTVsl6ymcJH2Mr9HJ-N4BfF6-HxeEuileIky3J_MCBoqghRZSYjt1Zuh7pMlCqv28Em85p8q0RzBtA.webp"),
-//                MeetingLeaveMember(id: 3, name: "채이", profileURL: "")
+                MeetingLeaveMember(
+                    id: 1,
+                    name: "수빈",
+                    // swiftlint:disable:next line_length
+                    profileURL: "https://i.namu.wiki/i/OXmmnGpQrbZ_6dYNGRIrCQEkKqgHZhBwxBU-KmfbjLZVknsUN8iXU2jYzVWFQb4P9qbVVHKiM5SfCa1_DXGLlS58m7UthtaWsCTmHlHvyvl6FR2kGRSYhZZ6T4Nr9nAeBUKMJpMzFrF6U-jvpunjgQ.webp"
+                ),
+                MeetingLeaveMember(
+                    id: 2,
+                    name: "유탁",
+                    // swiftlint:disable:next line_length
+                    profileURL: "https://i.namu.wiki/i/KSlJDAdoBtpnTzmwMv8dt4fXffy8CzUt4mTrzEptnyuc3ZGD9V-Qh8GNX_C7D6NSiwxl5n6aKTVsl6ymcJH2Mr9HJ-N4BfF6-HxeEuileIky3J_MCBoqghRZSYjt1Zuh7pMlCqv28Em85p8q0RzBtA.webp"
+                )
             ]
         )
         .background(Color.blue.opacity(0.1))
@@ -127,11 +136,21 @@ struct SelectOwnerView_Previews: PreviewProvider {
                 reducer: SelectOwnerFeature()
             ),
             meetingLeaveMember: [
-                MeetingLeaveMember(id: 1, name: "수빈", profileURL: "https://i.namu.wiki/i/OXmmnGpQrbZ_6dYNGRIrCQEkKqgHZhBwxBU-KmfbjLZVknsUN8iXU2jYzVWFQb4P9qbVVHKiM5SfCa1_DXGLlS58m7UthtaWsCTmHlHvyvl6FR2kGRSYhZZ6T4Nr9nAeBUKMJpMzFrF6U-jvpunjgQ.webp"),
-                MeetingLeaveMember(id: 2, name: "유탁", profileURL: "https://i.namu.wiki/i/KSlJDAdoBtpnTzmwMv8dt4fXffy8CzUt4mTrzEptnyuc3ZGD9V-Qh8GNX_C7D6NSiwxl5n6aKTVsl6ymcJH2Mr9HJ-N4BfF6-HxeEuileIky3J_MCBoqghRZSYjt1Zuh7pMlCqv28Em85p8q0RzBtA.webp"),
+                MeetingLeaveMember(
+                    id: 1,
+                    name: "수빈",
+                    // swiftlint:disable:next line_length
+                    profileURL: "https://i.namu.wiki/i/OXmmnGpQrbZ_6dYNGRIrCQEkKqgHZhBwxBU-KmfbjLZVknsUN8iXU2jYzVWFQb4P9qbVVHKiM5SfCa1_DXGLlS58m7UthtaWsCTmHlHvyvl6FR2kGRSYhZZ6T4Nr9nAeBUKMJpMzFrF6U-jvpunjgQ.webp"
+                ),
+                MeetingLeaveMember(
+                    id: 2,
+                    name: "유탁",
+                    // swiftlint:disable:next line_length
+                    profileURL: "https://i.namu.wiki/i/KSlJDAdoBtpnTzmwMv8dt4fXffy8CzUt4mTrzEptnyuc3ZGD9V-Qh8GNX_C7D6NSiwxl5n6aKTVsl6ymcJH2Mr9HJ-N4BfF6-HxeEuileIky3J_MCBoqghRZSYjt1Zuh7pMlCqv28Em85p8q0RzBtA.webp"
+                ),
                 MeetingLeaveMember(id: 3, name: "채이", profileURL: ""),
                 MeetingLeaveMember(id: 4, name: "선웅", profileURL: ""),
-                MeetingLeaveMember(id: 5, name: "관곤", profileURL: ""),
+                MeetingLeaveMember(id: 5, name: "관곤", profileURL: "")
             ]
         )
         .background(Color.blue.opacity(0.1))

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Date/CreateDateFeature.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Date/CreateDateFeature.swift
@@ -154,6 +154,7 @@ struct CreateDateFeature: ReducerProtocol {
                 }
                 
             case .selectDateAction(.dismiss):
+                // swiftlint:disable:next line_length
                 state.meetingDateButtonState.dateButtonStatus = state.meetingDateButtonState.dateButtonBeforeStatus
                 if state.meetingDateButtonState.timeButtonStatus == .inactive {
                     return .run { send in
@@ -178,6 +179,7 @@ struct CreateDateFeature: ReducerProtocol {
                 return .run { send in await send(.statusChanged) }
                 
             case .selectTimeAction(.dismiss):
+                // swiftlint:disable:next line_length
                 state.meetingDateButtonState.timeButtonStatus = state.meetingDateButtonState.timeButtonBeforeStatus
                 return .none
                 

--- a/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleView.swift
+++ b/Baggle/Baggle/Features/Tab/CreateMeeting/Title/CreateTitleView.swift
@@ -61,9 +61,8 @@ struct CreateTitleView: View {
                         }
                     }
                 }
-
                 .onOpenURL { url in
-                    if let id = url.params()?["id"] as? String {
+                    if url.params()?["id"] is String {
                         viewStore.send(.cancelButtonTapped)
                     }
                 }

--- a/Baggle/Baggle/Features/Tab/MainTab/MainTabFeature.swift
+++ b/Baggle/Baggle/Features/Tab/MainTab/MainTabFeature.swift
@@ -121,8 +121,8 @@ struct MainTabFeature: ReducerProtocol {
             case .selectTab(let tabType):
                 if tabType == .createMeeting {
                     state.createMeeting = CreateTitleFeature.State()
-                    state.previousTab = state.selectedTab
                 }
+                state.previousTab = state.selectedTab
                 state.selectedTab = tabType
                 return .none
 
@@ -324,7 +324,7 @@ struct MainTabFeature: ReducerProtocol {
                 // MARK: - Delegate
                 
             case .delegate(.moveToLogin):
-                state.selectedTab = .home // 로그아웃 후 재 진입시 기본 화면 홈 화면으로 설정
+//                state.selectedTab = .home // 로그아웃 후 재 진입시 기본 화면 홈 화면으로 설정
                 return .none
                 
             case .delegate:

--- a/Baggle/Baggle/Features/Tab/MainTab/MainTabView.swift
+++ b/Baggle/Baggle/Features/Tab/MainTab/MainTabView.swift
@@ -105,6 +105,7 @@ struct MainTabView: View {
             case .meetingDetail:
                 CaseLet(
                     /MainTabFeature.Child.State.meetingDetail,
+                     // swiftlint:disable:next vertical_parameter_alignment_on_call
                      action: MainTabFeature.Child.Action.meetingDetail
                 ) { store in
                     MeetingDetailView(store: store)
@@ -112,6 +113,7 @@ struct MainTabView: View {
             case .meetingEdit:
                 CaseLet(
                     /MainTabFeature.Child.State.meetingEdit,
+                     // swiftlint:disable:next vertical_parameter_alignment_on_call
                      action: MainTabFeature.Child.Action.meetingEdit
                 ) { store in
                     MeetingEditView(store: store)


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 

close #228 

## 내용
<!--
로직 설명  
--> 
1. swiftlint 반영 수정
2. 모임 상세 인증 후 emergencyStatus .termination으로 바꾸는 부분 수정 (기존 emergencyStatus 그대로 가져가도록)

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 
![ezgif com-resize (2)](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/81167570/dfebdf4a-8f2c-44db-bfb1-f56f04090f35)


## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

MeetingDetail 확인해주시면 될 것 같습니다
코드 한 줄 수정이라 그 외 swiftlint 수정까지 했습니다!

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
