### PR TITLE
Debug & Release 분리

### DIFF
--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -278,7 +278,7 @@
 		1406858A2A7B676D00824A93 /* CreateDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDescription.swift; sourceTree = "<group>"; };
 		140C54372A74F42900CF1CB4 /* NicknameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameValidator.swift; sourceTree = "<group>"; };
 		140C543D2A74F54B00CF1CB4 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
-		140E880D2A64B626005119F8 /* Baggle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Baggle.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		140E880D2A64B626005119F8 /* Baggle Develop.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Baggle Develop.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		140E88102A64B626005119F8 /* BaggleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaggleApp.swift; sourceTree = "<group>"; };
 		140E88122A64B626005119F8 /* AppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
 		140E88142A64B627005119F8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -579,7 +579,7 @@
 		140E880E2A64B626005119F8 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				140E880D2A64B626005119F8 /* Baggle.app */,
+				140E880D2A64B626005119F8 /* Baggle Develop.app */,
 				146C51D22A79139900FF3142 /* BaggleTests.xctest */,
 			);
 			name = Products;
@@ -1959,7 +1959,7 @@
 				14C8DAC62A8F542800371374 /* Lottie */,
 			);
 			productName = promiseDemo;
-			productReference = 140E880D2A64B626005119F8 /* Baggle.app */;
+			productReference = 140E880D2A64B626005119F8 /* Baggle Develop.app */;
 			productType = "com.apple.product-type.application";
 		};
 		146C51D12A79139900FF3142 /* BaggleTests */ = {
@@ -2462,6 +2462,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				BUNDLE_ID_SUFFIX = ".Baggle-dev";
 				CODE_SIGN_ENTITLEMENTS = Baggle/Baggle.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
@@ -2484,8 +2485,8 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.youtak.Baggle;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.youtak$(BUNDLE_ID_SUFFIX)";
+				PRODUCT_NAME = "$(TARGET_NAME) Develop";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Baggle Development";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -2502,6 +2503,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				BUNDLE_ID_SUFFIX = .Baggle;
 				CODE_SIGN_ENTITLEMENTS = Baggle/Baggle.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
@@ -2524,7 +2526,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.youtak.Baggle;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.youtak$(BUNDLE_ID_SUFFIX)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Baggle Distribution";

--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -2512,6 +2512,7 @@
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = YK6FBNFSV5;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_TESTABILITY = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Baggle/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "\"카메라 권한이 필요합니다\"";
@@ -2542,6 +2543,7 @@
 		146C51D82A79139900FF3142 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUNDLE_ID_SUFFIX = ".Baggle-dev";
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -2563,11 +2565,13 @@
 		146C51D92A79139900FF3142 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUNDLE_ID_SUFFIX = .Baggle;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = YK6FBNFSV5;
+				ENABLE_TESTABILITY = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;

--- a/Baggle/Baggle.xcodeproj/xcshareddata/xcschemes/Baggle Develop.xcscheme
+++ b/Baggle/Baggle.xcodeproj/xcshareddata/xcschemes/Baggle Develop.xcscheme
@@ -23,27 +23,14 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "146C51D12A79139900FF3142"
-               BuildableName = "BaggleTests.xctest"
-               BlueprintName = "BaggleTests"
-               ReferencedContainer = "container:Baggle.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -81,10 +68,10 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Release">
+      buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 
- close #274 

## 내용
<!--
로직 설명  
--> 

- Product Bundle Identifier를 분리했습니다. 
- Debug & Release 앱 이름을 분리했습니다. 
- "Baggle Develop" Scheme을 추가했습니다. 

개발할 때는 Baggle Develop scheme을 사용해서 개발용 URL을 사용하게 됩니다.   
앱 스토어에 올릴 때는 Baggle scheme을 사용해서 운영용 URL을 사용하게 됩니다.

Scheme 2개

![스크린샷 2023-09-24 오후 11 27 03](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/7e2dc6d6-46c9-46af-b9dd-934b488c90a5)

Baggle Develop Scheme

![스크린샷 2023-09-24 오후 11 27 14](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/094fae8e-f827-46b3-9797-78973502492c)


Baggle Scheme

![스크린샷 2023-09-24 오후 11 27 22](https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/f7a806b9-23a8-4b45-aaae-1f59549c4e68)

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

앱 이름 분리 

<img width = 300 src = "https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/6f02cbe9-e101-4817-9b82-33d8604a515b" />

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

앱 배포하고 나서 다운로드 받은 앱이랑 분리하려고 2개로 나눴습니다.


## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->

