### PR TITLE
Hotfix - Date Format 수정

### DIFF
--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		141E8CF72AA8A9BD00054EDA /* BaggleAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141E8CF62AA8A9BD00054EDA /* BaggleAlert.swift */; };
 		141FD7632A8CF609003DBFD7 /* MeetingSuccessModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141FD7622A8CF609003DBFD7 /* MeetingSuccessModel.swift */; };
 		1421C0512A7A84A200C20497 /* LoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1421C0502A7A84A200C20497 /* LoginService.swift */; };
+		142749132AC268D3009590A8 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146C51DF2A79143A00FF3142 /* Date+.swift */; };
 		14283FCF2A8DA32B00FE56F1 /* Moya+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14283FCE2A8DA32B00FE56F1 /* Moya+.swift */; };
 		142BEED72A8F19A100B91426 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142BEED62A8F19A100B91426 /* UserManager.swift */; };
 		142BEED92A8F213B00B91426 /* UserToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142BEED82A8F213B00B91426 /* UserToken.swift */; };
@@ -2113,6 +2114,7 @@
 				2B84696D2A6E7AE200D75D32 /* ShadeView.swift in Sources */,
 				2B437FBA2A93B64C004DC68E /* AlertJoinMeetingType.swift in Sources */,
 				2B42A5852AA4C26400E97CB1 /* LogoutService.swift in Sources */,
+				142749132AC268D3009590A8 /* Date+.swift in Sources */,
 				2BABCB282A76D08400AFECA3 /* PostObserverAction.swift in Sources */,
 				1432BE6D2A682FCB0098AAA9 /* HomeView.swift in Sources */,
 				2B409D7C2A80BE840051A3BC /* Font+.swift in Sources */,

--- a/Baggle/Baggle.xcodeproj/project.pbxproj
+++ b/Baggle/Baggle.xcodeproj/project.pbxproj
@@ -76,7 +76,6 @@
 		146237482A87803F00FBE121 /* SafariWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146237472A87803F00FBE121 /* SafariWebView.swift */; };
 		146C51D52A79139900FF3142 /* BaggleDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146C51D42A79139900FF3142 /* BaggleDateTests.swift */; };
 		146C51DD2A7913B400FF3142 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 146C51DC2A7913B400FF3142 /* FirebaseMessaging */; };
-		146C51E02A79143A00FF3142 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146C51DF2A79143A00FF3142 /* Date+.swift */; };
 		146C51E92A793D3F00FF3142 /* BaggleDatePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146C51E82A793D3F00FF3142 /* BaggleDatePickerView.swift */; };
 		146C51EB2A79406700FF3142 /* BaggleTimePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146C51EA2A79406700FF3142 /* BaggleTimePickerView.swift */; };
 		146C51EE2A79429400FF3142 /* SelectDateFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146C51ED2A79429400FF3142 /* SelectDateFeature.swift */; };
@@ -2260,7 +2259,6 @@
 				14B7A0452A75409E00B8E202 /* APIError.swift in Sources */,
 				2BA760BB2A81EB610089878D /* String+.swift in Sources */,
 				140C54382A74F42900CF1CB4 /* NicknameValidator.swift in Sources */,
-				146C51E02A79143A00FF3142 /* Date+.swift in Sources */,
 				14C8DACE2A8F645D00371374 /* LottieView.swift in Sources */,
 				2B30E33C2A6F9DD500949151 /* UserDefaultWrapper.swift in Sources */,
 				146C51F22A7950F000FF3142 /* SelectTimeFeature.swift in Sources */,

--- a/Baggle/Baggle.xcodeproj/xcshareddata/xcschemes/Baggle.xcscheme
+++ b/Baggle/Baggle.xcodeproj/xcshareddata/xcschemes/Baggle.xcscheme
@@ -62,13 +62,6 @@
             ReferencedContainer = "container:Baggle.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "TZ"
-            value = "America/Los_Angeles"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Baggle/Baggle.xcodeproj/xcshareddata/xcschemes/Baggle.xcscheme
+++ b/Baggle/Baggle.xcodeproj/xcshareddata/xcschemes/Baggle.xcscheme
@@ -62,6 +62,13 @@
             ReferencedContainer = "container:Baggle.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "TZ"
+            value = "America/Los_Angeles"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Baggle/Baggle/Core/Common/Extensions/Date/Date+.swift
+++ b/Baggle/Baggle/Core/Common/Extensions/Date/Date+.swift
@@ -105,9 +105,9 @@ extension Date {
     func toString(format: String) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = format
-        dateFormatter.timeZone = TimeZone(abbreviation: "KST")
+//        dateFormatter.timeZone = TimeZone(abbreviation: "KST")
         dateFormatter.calendar = Calendar(identifier: .iso8601)
-        dateFormatter.locale = Locale(identifier: "ko_kr")
+//        dateFormatter.locale = Locale(identifier: "ko_kr")
         return dateFormatter.string(from: self)
     }
 
@@ -212,17 +212,17 @@ extension Date {
     func meetingStartTime() -> Date {
 
         // 2시간 이후
-        let twoHoursLater = self.later(hours: 2)
+        let oneHoursLater = self.later(hours: 1)
 
         // 5분 이후
-        var twoHoursFiveMinutesLater = twoHoursLater.later(minutes: 10)
+        var oneHoursFiveMinutesLater = oneHoursLater.later(minutes: 10)
 
         // 5분 단위로 만들기
-        while twoHoursFiveMinutesLater.minute % 5 != 0 {
-            twoHoursFiveMinutesLater.minute -= 1
+        while oneHoursFiveMinutesLater.minute % 5 != 0 {
+            oneHoursFiveMinutesLater.minute -= 1
         }
 
-        return twoHoursFiveMinutesLater
+        return oneHoursFiveMinutesLater
     }
 
 

--- a/Baggle/Baggle/DesignSystem/View/Date/Picker/BaggleDatePickerView.swift
+++ b/Baggle/Baggle/DesignSystem/View/Date/Picker/BaggleDatePickerView.swift
@@ -24,7 +24,6 @@ struct BaggleDatePickerView: View {
         )
         .labelsHidden()
         .datePickerStyle(.wheel)
-        .environment(\.locale, Locale.init(identifier: "ko_kr"))
     }
 }
 

--- a/Baggle/Baggle/DesignSystem/View/Date/Picker/BaggleTimePickerView.swift
+++ b/Baggle/Baggle/DesignSystem/View/Date/Picker/BaggleTimePickerView.swift
@@ -24,7 +24,6 @@ struct BaggleTimePickerView: View {
         }
         .labelsHidden()
         .datePickerStyle(.wheel)
-        .environment(\.locale, Locale.init(identifier: "ko_kr"))
     }
 }
 


### PR DESCRIPTION
Date Formatter 때문에 빠꾸 먹었습니다 🥲 

## 내용
<!--
로직 설명  
--> 
- Date -> String으로 바꿀 때 한국 시간으로 고정되어있던 거 삭제했습니다.
  - 서버와 통신할 때만 Baggle Date Formatter를 사용해 KST로 변경합니다.

ex) 미국인 경우
모임 미국 시간 -> 요청 전에 한국 시간으로 변경 -> 서버로 보냄
서버에서 한국 시간 보냄 -> 응답 받고 기기 시간대로 변경 -> 모임 미국 시간

- 모임 생성 시간 2시간 -> 1시간 후로 변경했습니다.


### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

빠꾸먹은 이미지

<img width = 300 src = "https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/d55c764c-2033-4ca4-a3e8-f8bffa0e52f6" />

수정 후 - 시뮬레이터 시간대 미국 시간으로 고정 후 실행


https://github.com/dnd-side-project/dnd-9th-2-ios/assets/71776532/5791b8be-2781-409b-ae99-496272d769a9



## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

- 한국 시간대만 했더니 바로 빠꾸먹었네요...

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
- 현재 Baggle Develop에서 카카오 로그인 안돼요. 카카오 API에서 Develop 전용 Key 를 새로 받아야 할 것 같아요.
