### PR TITLE
Fix - 토큰 만료시 로그인으로 이동

### DIFF
--- a/Baggle/Baggle/Core/Common/Extensions/Foundation/Task+.swift
+++ b/Baggle/Baggle/Core/Common/Extensions/Foundation/Task+.swift
@@ -32,7 +32,7 @@ extension Task where Failure == Error {
                             if await TokenRefreshService.refresh() == .success {
                                 continue
                             } else {
-                                throw APIError.unauthorized
+                                throw APIError.tokenExpired
                             }
                         }
                     }

--- a/Baggle/Baggle/Core/Services/Emergency/EmergencyService.swift
+++ b/Baggle/Baggle/Core/Services/Emergency/EmergencyService.swift
@@ -43,6 +43,8 @@ extension EmergencyService: DependencyKey {
                     return .unAuthorized
                 } else if apiError == .notFound {
                     return .notFound
+                } else if apiError == .tokenExpired {
+                    return .userError
                 }
             }
             return .networkError(error.localizedDescription)

--- a/Baggle/Baggle/Core/Services/Error/APIError.swift
+++ b/Baggle/Baggle/Core/Services/Error/APIError.swift
@@ -19,6 +19,7 @@ enum APIError: Error, Equatable {
 
     case authorizeFail // 401, 토큰 인증 실패
     case unauthorized // 401, 토큰 만료 에러 (재발급 X)
+    case tokenExpired // 401, 리프레시 토큰 만료
     
     // MARK: - 403
 
@@ -64,6 +65,7 @@ extension APIError: LocalizedError {
             
         case .authorizeFail: return "401 인증 실패"
         case .unauthorized: return "401 인증 불가"
+        case .tokenExpired: return "401 토큰 만료"
             
             // MARK: - 403
             

--- a/Baggle/Baggle/Core/Services/Feed/FeedPhotoService.swift
+++ b/Baggle/Baggle/Core/Services/Feed/FeedPhotoService.swift
@@ -45,6 +45,8 @@ extension FeedPhotoService: DependencyKey {
                     return .notFound
                 case .duplicatedUser:
                     return .alreadyUpload
+                case .tokenExpired:
+                    return .userError
                 default:
                     return .networkError(apiError.localizedDescription)
                 }

--- a/Baggle/Baggle/Core/Services/Feed/FeedReportService.swift
+++ b/Baggle/Baggle/Core/Services/Feed/FeedReportService.swift
@@ -37,6 +37,9 @@ extension FeedReportService: DependencyKey {
             }).value
         } catch {
             guard let error = error as? APIError else { return .fail(.network) }
+            if error == .tokenExpired {
+                return .userError
+            }
             return .fail(error)
         }
     }

--- a/Baggle/Baggle/Core/Services/Home/MeetingListService.swift
+++ b/Baggle/Baggle/Core/Services/Home/MeetingListService.swift
@@ -32,6 +32,9 @@ extension MeetingListService: DependencyKey {
             }.value
         } catch {
             print("❌ MeetingListService - error: \(error)")
+            if error as? APIError == .tokenExpired {
+                return .userError
+            }
             return .networkError(error.localizedDescription)
         }
     }

--- a/Baggle/Baggle/Core/Services/JoinMeeting/JoinMeetingService.swift
+++ b/Baggle/Baggle/Core/Services/JoinMeeting/JoinMeetingService.swift
@@ -38,6 +38,8 @@ extension JoinMeetingService: DependencyKey {
             guard let error = error as? APIError else { return .fail(.network) }
             if error == .duplicatedJoinMeeting {
                 return JoinMeetingResult.joined
+            } else if error == .tokenExpired {
+                return JoinMeetingResult.expired(.tokenExpired)
             } else {
                 return JoinMeetingResult.expired(error)
             }

--- a/Baggle/Baggle/Core/Services/Meeting/MeetingCreate/MeetingCreateService.swift
+++ b/Baggle/Baggle/Core/Services/Meeting/MeetingCreate/MeetingCreateService.swift
@@ -49,6 +49,8 @@ extension MeetingCreateService: DependencyKey {
                     return .duplicatedMeeting
                 } else if apiError == .limitMeetingCount {
                     return .limitMeetingCount
+                } else if apiError == .tokenExpired {
+                    return .userError
                 }
             }
             return .networkError(error.localizedDescription)

--- a/Baggle/Baggle/Core/Services/Meeting/MeetingDelete/MeetingDeleteService.swift
+++ b/Baggle/Baggle/Core/Services/Meeting/MeetingDelete/MeetingDeleteService.swift
@@ -38,8 +38,12 @@ extension MeetingDeleteService: DependencyKey {
                 return .successDelegate
             }.value
         } catch {
-            if let apiError = error as? APIError, apiError == .invalidMeetingDeleteTime {
-                return .invalidDeleteTime
+            if let apiError = error as? APIError {
+                if apiError == .invalidMeetingDeleteTime {
+                    return .invalidDeleteTime
+                } else if apiError == .tokenExpired {
+                    return .userError
+                }
             }
             
             return .networkError
@@ -61,8 +65,12 @@ extension MeetingDeleteService: DependencyKey {
                 return .successLeave
             }.value
         } catch {
-            if let apiError = error as? APIError, apiError == .invalidMeetingDeleteTime {
-                return .invalidDeleteTime
+            if let apiError = error as? APIError {
+                if apiError == .invalidMeetingDeleteTime {
+                    return .invalidDeleteTime
+                } else if apiError == .tokenExpired {
+                    return .userError
+                }
             }
             
             return .networkError
@@ -84,8 +92,12 @@ extension MeetingDeleteService: DependencyKey {
                 return .successDelete
             }.value
         } catch {
-            if let apiError = error as? APIError, apiError == .invalidMeetingDeleteTime {
-                return .invalidDeleteTime
+            if let apiError = error as? APIError {
+                if apiError == .invalidMeetingDeleteTime {
+                    return .invalidDeleteTime
+                } else if apiError == .tokenExpired {
+                    return .userError
+                }
             }
             
             return .networkError

--- a/Baggle/Baggle/Core/Services/Meeting/MeetingDetail/MeetingDetailService.swift
+++ b/Baggle/Baggle/Core/Services/Meeting/MeetingDetail/MeetingDetailService.swift
@@ -38,7 +38,7 @@ extension MeetingDetailService: DependencyKey {
             if let apiError = error as? APIError {
                 if apiError == .notFound {
                     return .notFound
-                } else if apiError == .unauthorized {
+                } else if apiError == .unauthorized || apiError == .tokenExpired {
                     return .userError
                 }
             } else if let keyChainError = error as? KeyChainError {

--- a/Baggle/Baggle/Core/Services/Meeting/MeetingEdit/MeetingEditService.swift
+++ b/Baggle/Baggle/Core/Services/Meeting/MeetingEdit/MeetingEditService.swift
@@ -39,6 +39,9 @@ extension MeetingEditService: DependencyKey {
                 return .success(meetingEditSuccessModel)
             }.value
         } catch {
+            if error as? APIError == .tokenExpired {
+                return .userError
+            }
             return .networkError(error.localizedDescription)
         }
     }

--- a/Baggle/Baggle/Core/Services/SignUp/SignUpService.swift
+++ b/Baggle/Baggle/Core/Services/SignUp/SignUpService.swift
@@ -39,6 +39,8 @@ extension SignUpService: DependencyKey {
         } catch {
             if (error as? APIError) == APIError.duplicatedNickname {
                 return .nicknameDuplicated
+            } else if (error as? APIError) == .tokenExpired {
+                return .userError
             } else if let error = error as? KeyChainError {
                 return .userError
             } else {

--- a/Baggle/Baggle/Core/Services/Tab/LogoutService.swift
+++ b/Baggle/Baggle/Core/Services/Tab/LogoutService.swift
@@ -30,6 +30,9 @@ extension LogoutService: DependencyKey {
                 return .success
             }.value
         } catch {
+            if error as? APIError == APIError.tokenExpired {
+                return .userError
+            }
             return .networkError(error.localizedDescription)
         }
     }

--- a/Baggle/Baggle/Core/Services/Tab/WithdrawService.swift
+++ b/Baggle/Baggle/Core/Services/Tab/WithdrawService.swift
@@ -33,6 +33,9 @@ extension WithdrawService: DependencyKey {
                 return .success
             }.value
         } catch {
+            if error as? APIError == .tokenExpired {
+                return .userError
+            }
             return .networkError(error.localizedDescription)
         }
     }

--- a/Baggle/Baggle/Features/JoinMeeting/JoinMeetingFeature.swift
+++ b/Baggle/Baggle/Features/JoinMeeting/JoinMeetingFeature.swift
@@ -78,6 +78,8 @@ struct JoinMeetingFeature: ReducerProtocol {
                         return .run { send in await send(.alertTypeChanged(.overlap))}
                     case .exceedMemberCount:
                         return .run { send in await send(.alertTypeChanged(.exceedMemberCount))}
+                    case .tokenExpired:
+                        return .run { send in await send(.alertTypeChanged(.userError)) }
                     default:
                         return .run { send in await send(.alertTypeChanged(.expired))}
                     }


### PR DESCRIPTION
## 관련 이슈
<!--
이슈 번호 #000 작성  
ex) close #1 
--> 

closed #282 

## 내용
<!--
로직 설명  
--> 

retrying으로 jwt 토큰 재시도했는데 리프레시 토큰까지 만료된 경우, 재로그인하도록 화면 전환 연결
- 기존의 유저정보에러(userError)와 처리하는 플로우가 동일하기 때문에 토큰 만료인 경우 userError alert를 띄우도록 재사용했습니다.

### 이미지, 영상
<!--
필요시 스크린샷 첨부
--> 

리프레시 토큰이 만료가 안되어서 확인을 제대로 못했는데, 확인되면 코멘트 남겨두겠습니다!

## 리뷰어가 확인할 사항
<!--
중점적으로 봐주면 좋을 사항  
ex) ㅇㅇㅇㅇ하려고 Combine 사용했는데 제대로 사용하고 있는건가요?
--> 

## 기타
<!--
레퍼런스 혹은 패키지 설치 등
-->
